### PR TITLE
Up libicu version to 74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get upgrade -y \
         libgcc1 \
         libgcc-s1 \
         libgssapi-krb5-2 \
-        libicu70 \
+        libicu74 \
         liblttng-ust1 \
         libssl3 \
         libstdc++6 \


### PR DESCRIPTION
Hey, the build works great, thanks!
Only had to change the libicu version to make it work, as linuxserver/code-server is now using Ubuntu 24.
![image](https://github.com/user-attachments/assets/9e0806cf-efad-40e7-9e83-97c1496816b0)
