### PR TITLE
Pin NBGV public-release classification per matrix leg

### DIFF
--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -46,6 +46,8 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
+      # Pin NBGV's public-release classification to this leg's branch (see get-version-task header).
+      branch: ${{ inputs.branch }}
 
   # Build only when validation passed (success) or was skipped (smoke); never when it failed.
   build-docker:

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -1,12 +1,18 @@
 name: Get version information task
 
-# Run NBGV once and expose the version outputs. The publisher passes an explicit ref per matrix leg so a scheduled
-# run (whose github.ref is always the default branch) still versions develop correctly.
+# Run NBGV once and expose the version outputs. NBGV classifies public-release by GITHUB_REF, not the checked-out
+# branch, so the caller passes the leg's `branch` and this task pins GITHUB_REF to it - otherwise a scheduled or
+# dispatch run (whose github.ref is always the default branch) misclassifies the develop leg as a public release.
 on:
   workflow_call:
     inputs:
       # Git ref to check out / version (empty = caller's default checkout ref).
       ref:
+        required: false
+        type: string
+        default: ''
+      # Logical branch this version belongs to; pins GITHUB_REF so NBGV classifies public-release per leg (see header).
+      branch:
         required: false
         type: string
         default: ''
@@ -50,4 +56,8 @@ jobs:
 
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
+        env:
+          # NBGV reads GITHUB_REF (not the checked-out HEAD) for publicReleaseRefSpec. Pin it to the leg's branch
+          # so develop is never misclassified as main's public release on a dispatch/schedule run from main.
+          GITHUB_REF: ${{ inputs.branch != '' && format('refs/heads/{0}', inputs.branch) || github.ref }}
         uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -127,6 +127,13 @@ specific commit to build it, but consumes the threaded version. `main` (the publ
 `X.Y.<height>-g<sha>`. *Keeps the built image's version label and the release tag in agreement.* NBGV needs
 only `version.json` and git history, so it works although the repo builds no .NET assembly.
 
+NBGV matches `publicReleaseRefSpec` against the `GITHUB_REF` environment variable, **not** the checked-out
+HEAD. On the matrix publisher `GITHUB_REF` is always the dispatch/schedule ref (the default branch), which
+would misclassify the develop leg as a public release (a clean version, risking a `:SemVer2` Docker-tag
+collision with `main`). So `get-version-task` takes the leg's `branch` and pins
+`GITHUB_REF=refs/heads/<branch>` for the NBGV step, making each leg classify against its own branch. *Prevents
+the develop leg publishing a clean (non-prerelease) version.*
+
 ### Validate at entry
 
 A run that carries a cross-input invariant (e.g. `main` must not carry a prerelease suffix) asserts it once


### PR DESCRIPTION
## Problem

On the schedule/dispatch matrix publisher, the develop leg published a **clean** `1.1.1` instead of the prerelease `1.1.1-g<sha>`. NBGV matches `publicReleaseRefSpec` against the **`GITHUB_REF`** env var, not the checked-out HEAD; on a dispatch from `main`, `GITHUB_REF=refs/heads/main` for the whole run, so the develop leg was classified `PublicRelease: true`.

A clean develop version risks overwriting `main`'s stable `:SemVer2` Docker tag once develop's height catches up to main's (the moving `:latest`/`:develop` tags and the release `prerelease` flag still distinguish them; only the immutable `:SemVer2` tag is at risk).

Confirmed: the develop checkout was on-branch (`Switched to a new branch 'develop'`) yet NBGV reported `PublicRelease: true` and `SemVer2: 1.1.1`.

## Fix

- `get-version-task.yml` takes the leg's `branch` and pins `GITHUB_REF=refs/heads/<branch>` on the NBGV step, falling back to `github.ref` when no `branch` is passed (so push CI is unchanged).
- `build-release-task.yml` threads `inputs.branch` into the get-version call.
- WORKFLOW.md documents the mechanism in the versioning section.

After this lands and the publisher is re-dispatched: `main` -> clean `X.Y.Z`, `develop` -> `X.Y.Z-g<sha>`.

## Verification

actionlint, markdownlint clean. The behavior is also being backported to the sibling Docker repos (PlexCleaner et al.), which have the identical latent issue.