### PR TITLE
Simplify publisher to one branch per run; fix NBGV classification

### DIFF
--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -2,8 +2,8 @@ name: Build Docker image task
 
 # Builds the multi-arch image (linux/amd64,arm64) and, on a main publish, pushes it plus the Docker Hub overview.
 # Branch drives the moving tag: main => `latest`, else `develop`, plus the `:SemVer2` tag. Smoke builds amd64 only
-# and never pushes; registry buildcache is branch-scoped. The orchestrator always passes `branch` (the publisher
-# builds develop from a main-ref run, so a github.ref_name fallback would mistag it).
+# and never pushes; registry buildcache is branch-scoped. The orchestrator passes `branch` explicitly (the
+# publisher builds one branch per run - the trigger ref - and smoke passes github.ref_name).
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
         default: ''
-      # Logical branch driving config, tags, and prerelease. Required (see header); the publisher builds both branches.
+      # Logical branch driving config, tags, and prerelease. Required (see header); the publisher passes the run's branch.
       branch:
         required: true
         type: string

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
 
-  # Validate the branch this leg publishes (lint), gating the build/publish below. Skipped on smoke: the PR runs
+  # Validate the branch being published (lint), gating the build/publish below. Skipped on smoke: the PR runs
   # its own validate job, so a smoke build does not double-validate.
   validate:
     name: Validate job

--- a/.github/workflows/build-release-task.yml
+++ b/.github/workflows/build-release-task.yml
@@ -46,8 +46,6 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
-      # Pin NBGV's public-release classification to this leg's branch (see get-version-task header).
-      branch: ${{ inputs.branch }}
 
   # Build only when validation passed (success) or was skipped (smoke); never when it failed.
   build-docker:

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -1,7 +1,7 @@
 name: Get version information task
 
-# Run NBGV once and expose the version outputs. The publisher passes an explicit ref so a run started from a
-# different branch still versions the checked-out branch (see the IGNORE_GITHUB_REF note on the nbgv step).
+# Run NBGV once and expose the version outputs. The caller checks out the branch being published (the run's own
+# ref), so github.ref matches it and NBGV classifies public-release (main) vs prerelease correctly.
 on:
   workflow_call:
     inputs:
@@ -50,10 +50,4 @@ jobs:
 
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
-        env:
-          # Version from the checked-out branch, not the CI ref. GITHUB_REF is reserved and a step env can't reliably
-          # override it (the runner re-injects the dispatch ref), so a run started from one branch would otherwise have
-          # NBGV classify against that ref. IGNORE_GITHUB_REF makes NBGV ignore GITHUB_REF and use the checked-out
-          # branch, which is the branch being published. The main-version backstop catches any misclassification.
-          IGNORE_GITHUB_REF: "true"
         uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -1,7 +1,9 @@
 name: Get version information task
 
-# Run NBGV once and expose the version outputs. The caller checks out the branch being published (the run's own
-# ref), so github.ref matches it and NBGV classifies public-release (main) vs prerelease correctly.
+# Run NBGV once and expose the version outputs. Checks out `inputs.ref` (default: the run's ref) and lets NBGV
+# classify public-release from github.ref. Callers are expected to version the branch the run is for - the
+# publisher builds the trigger ref - so github.ref matches the versioned branch and the classification
+# (main = public clean version, any other branch = prerelease) is correct without overriding github.ref.
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/get-version-task.yml
+++ b/.github/workflows/get-version-task.yml
@@ -1,18 +1,12 @@
 name: Get version information task
 
-# Run NBGV once and expose the version outputs. NBGV classifies public-release by GITHUB_REF, not the checked-out
-# branch, so the caller passes the leg's `branch` and this task pins GITHUB_REF to it - otherwise a scheduled or
-# dispatch run (whose github.ref is always the default branch) misclassifies the develop leg as a public release.
+# Run NBGV once and expose the version outputs. The publisher passes an explicit ref so a run started from a
+# different branch still versions the checked-out branch (see the IGNORE_GITHUB_REF note on the nbgv step).
 on:
   workflow_call:
     inputs:
       # Git ref to check out / version (empty = caller's default checkout ref).
       ref:
-        required: false
-        type: string
-        default: ''
-      # Logical branch this version belongs to; pins GITHUB_REF so NBGV classifies public-release per leg (see header).
-      branch:
         required: false
         type: string
         default: ''
@@ -57,7 +51,9 @@ jobs:
       - name: Run Nerdbank.GitVersioning tool step
         id: nbgv
         env:
-          # NBGV reads GITHUB_REF (not the checked-out HEAD) for publicReleaseRefSpec. Pin it to the leg's branch
-          # so develop is never misclassified as main's public release on a dispatch/schedule run from main.
-          GITHUB_REF: ${{ inputs.branch != '' && format('refs/heads/{0}', inputs.branch) || github.ref }}
+          # Version from the checked-out branch, not the CI ref. GITHUB_REF is reserved and a step env can't reliably
+          # override it (the runner re-injects the dispatch ref), so a run started from one branch would otherwise have
+          # NBGV classify against that ref. IGNORE_GITHUB_REF makes NBGV ignore GITHUB_REF and use the checked-out
+          # branch, which is the branch being published. The main-version backstop catches any misclassification.
+          IGNORE_GITHUB_REF: "true"
         uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,20 +1,21 @@
 name: Publish project release action
 
-# Scheduled + on-demand publisher. The weekly run (and a manual dispatch) builds and publishes BOTH
-# branches in full: multi-arch Docker image + GitHub release (a version anchor). main publishes a stable
-# release (`latest` image), develop a prerelease (`develop` image).
+# Scheduled + on-demand publisher, one run = one branch (the trigger ref). The weekly schedule rebuilds
+# `main` only (refreshing the `latest` image for base-image CVEs); a manual dispatch publishes the branch it
+# is dispatched from (main => stable/`latest`, develop => prerelease/`develop`). Building only the trigger
+# branch keeps github.ref aligned with the branch being versioned, so NBGV classifies it correctly with no
+# matrix and no cross-branch ref leak.
 #
-# Merges do NOT publish: accumulated changes (mostly Dependabot bumps) ship in the next weekly run, and
-# the rebuild also refreshes the base image (lscr.io/linuxserver/code-server) for CVEs. A maintainer
-# dispatches to release on demand. CI/validation runs separately on push (test-pull-request); this
-# workflow never runs on push.
+# Merges do NOT publish: accumulated changes (mostly Dependabot bumps) ship in the next scheduled run, which
+# also refreshes the base image (lscr.io/linuxserver/code-server). To release develop, dispatch this workflow
+# from the develop branch. CI/validation runs separately on push (test-pull-request); this never runs on push.
 on:
   workflow_dispatch:
   schedule:
-    # Weekly full publish of both branches (Mon 02:00 UTC).
+    # Weekly rebuild/publish of main (Mon 02:00 UTC) to pick up base-image updates.
     - cron: '0 2 * * MON'
 
-# Global, ref-independent group so publishes serialize (shared Docker tags, both-branch releases).
+# Global, ref-independent group so publishes serialize (shared Docker tags / Hub overview).
 # cancel-in-progress: false so a publish is never cancelled mid-release.
 concurrency:
   group: ${{ github.workflow }}
@@ -22,26 +23,21 @@ concurrency:
 
 jobs:
 
-  # Publish each branch in full (Docker + GitHub release). Each leg validates, checks out, and
-  # versions its own branch ref (build-release-task gates the build on its own validate job), so a failing
-  # test or lint on either branch blocks only that leg. The no-op guard skips release creation when the
-  # version is unchanged; the Docker push still refreshes the base image.
+  # Publish the trigger branch in full (Docker + GitHub release). The schedule always runs on the default
+  # branch (main); a dispatch runs on whatever branch it is started from. build-release-task validates,
+  # versions, and tags that one branch; the no-op guard skips release creation when the version is unchanged
+  # while the Docker push still refreshes the base image.
   publish:
     name: Publish project release job
-    # A dispatch must come from the default branch (main): the publisher builds both branches from their own
-    # refs, but the workflow logic itself resolves from the dispatch ref, so restrict it for predictability.
-    if: ${{ github.event_name == 'schedule' || github.ref_name == 'main' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [main, develop]
+    # Only the long-lived branches publish; a stray dispatch from a feature branch is a no-op.
+    if: ${{ github.ref_name == 'main' || github.ref_name == 'develop' }}
     uses: ./.github/workflows/build-release-task.yml
     secrets: inherit
     permissions:
       contents: write
     with:
-      ref: ${{ matrix.branch }}
-      branch: ${{ matrix.branch }}
+      ref: ${{ github.ref_name }}
+      branch: ${{ github.ref_name }}
       smoke: false
       github: true
       dockerhub: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,8 +15,8 @@ on:
     # Weekly rebuild/publish of main (Mon 02:00 UTC) to pick up base-image updates.
     - cron: '0 2 * * MON'
 
-# Global, ref-independent group so publishes serialize (shared Docker tags / Hub overview).
-# cancel-in-progress: false so a publish is never cancelled mid-release.
+# Global, ref-independent group so two publishes never overlap (a schedule + a manual dispatch, or back-to-back
+# dispatches). cancel-in-progress: false so a publish is never cancelled mid-release.
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -6,8 +6,8 @@ name: Validate task
 on:
   workflow_call:
     inputs:
-      # Git ref to validate (empty = default checkout ref). The publisher passes each branch so its leg
-      # validates the branch it publishes.
+      # Git ref to validate (empty = default checkout ref). The publisher passes its trigger branch so the
+      # publish run validates the branch it publishes.
       ref:
         required: false
         type: string

--- a/.github/workflows/validate-task.yml
+++ b/.github/workflows/validate-task.yml
@@ -2,7 +2,7 @@ name: Validate task
 
 # The validation gate: lint the docs and workflows (markdownlint, cspell, actionlint). No unit tests or C#
 # formatting - this repo has no compiled code. Reused by test-pull-request (produces the required check) and
-# each publish leg, so the CI and publish gates are identical.
+# the publish run, so the CI and publish gates are identical.
 on:
   workflow_call:
     inputs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ This file is the canonical reference for cross-cutting AI-agent rules. The CI/CD
 
 ## Release Model
 
-The publish behavior - the **weekly scheduled + on-demand** publisher (both branches built in one run: a multi-arch Docker image + a GitHub release that anchors the version), branch-scoped versioning (`main` = stable / `latest`, `develop` = prerelease / `develop`), and the rule that **merges do not publish** (changes accumulate and ship in the next weekly run, which also refreshes the `lscr.io/linuxserver/code-server` base image) - is specified in [`WORKFLOW.md`](./WORKFLOW.md), the canonical CI/CD guide. Do not duplicate those rules here.
+The publish behavior - the **scheduled + on-demand** publisher (one branch per run: the weekly schedule rebuilds `main`, and a dispatch publishes the branch it is started from - a multi-arch Docker image + a GitHub release that anchors the version), branch-scoped versioning (`main` = stable / `latest`, `develop` = prerelease / `develop`), and the rule that **merges do not publish** (changes accumulate and ship in the next scheduled run, which also refreshes the `lscr.io/linuxserver/code-server` base image; release `develop` by dispatching from `develop`) - is specified in [`WORKFLOW.md`](./WORKFLOW.md), the canonical CI/CD guide. Do not duplicate those rules here.
 
 Versioning is the one release rule that is a **human process**, not a workflow outcome, so it lives here:
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -81,8 +81,8 @@ Legibility rules. Necessary but not sufficient: a perfectly styled workflow can 
   with the live ruleset.
 - **Concurrency.** Every entry workflow declares a `concurrency` group. CI uses
   `group: '${{ github.workflow }}-${{ github.ref }}'`, `cancel-in-progress: true`. The publisher overrides
-  it: a ref-independent group with `cancel-in-progress: false`, so a `main` and a `develop` publish serialize
-  (they share the Docker Hub overview and registry) and none is cancelled mid-release.
+  it: a ref-independent group with `cancel-in-progress: false`, so two publishes never overlap (a schedule and
+  a manual dispatch, or back-to-back dispatches) and none is cancelled mid-release.
 - **Shells.** Every multi-line bash `run:` starts with `set -euo pipefail`.
 - **Conditionals.** Multi-line `if:` uses the folded scalar `if: >-`.
 - **Boolean inputs.** A boolean used by both `workflow_call` and `workflow_dispatch` is declared in both
@@ -125,11 +125,12 @@ commit to build it, but consumes the threaded version. `main` (the public ref,
 `X.Y.<height>-g<sha>`. *Keeps the built image's version label and the release tag in agreement.* NBGV needs
 only `version.json` and git history, so it works although the repo builds no .NET assembly.
 
-NBGV classifies `publicReleaseRefSpec` from the `GITHUB_REF` environment variable, **not** the checked-out
-HEAD, and `GITHUB_REF` is reserved (a step `env:` cannot reliably override it - the runner re-injects the real
-ref). The nbgv step therefore sets `IGNORE_GITHUB_REF: "true"`, making NBGV ignore `GITHUB_REF` and classify
-from the **checked-out branch** - which here is always the published branch. *Prevents a develop build being
-classified as main's public (clean) version.* The main-version backstop (D2.2) catches any misclassification.
+NBGV classifies `publicReleaseRefSpec` from the `GITHUB_REF` environment variable. Because the publisher builds
+the **trigger ref** (one branch per run), `GITHUB_REF` already equals the branch being versioned - a schedule
+or `main` dispatch classifies as public (clean `X.Y.Z`), a `develop` dispatch as prerelease (`X.Y.Z-g<sha>`) -
+so no `GITHUB_REF` override is needed. (`GITHUB_REF` is reserved and cannot be reliably overridden anyway; the
+matrix publishers that build a non-trigger branch are the ones that need `IGNORE_GITHUB_REF`.) The main-version
+backstop (D2.2) catches any misclassification.
 
 ### Validate at entry
 
@@ -212,8 +213,8 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 ### D3 - Versioning and classification
 
 - **D3.1 NBGV runs once, threaded.** Output: NBGV runs once, classifying from the checked-out branch; no
-  consumer re-invokes it. The nbgv step sets `IGNORE_GITHUB_REF: "true"` so NBGV classifies from that branch,
-  not the reserved `GITHUB_REF` (which a dispatch run cannot reliably override).
+  consumer re-invokes it. The run builds the trigger ref, so `GITHUB_REF` already matches the branch being
+  versioned and NBGV classifies it correctly (no override needed).
 - **D3.2 `main` = stable, others = prerelease.** Output: `main` -> `X.Y.Z`, any other branch ->
   `X.Y.Z-g<sha>`. The release-version backstop and the GitHub-release `prerelease` expression name `main`;
   `publicReleaseRefSpec` is `^refs/heads/main$`.
@@ -322,7 +323,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 
 - **D0:** CI has no branch matrix; the publisher's single `publish` job passes `github.ref_name` as
   `ref`/`branch` and is guarded to `main`/`develop`; NBGV invoked once, every other consumer reads it via
-  `needs:`; the nbgv step sets `IGNORE_GITHUB_REF: "true"`.
+  `needs:`; the run builds the trigger ref so `GITHUB_REF` matches the versioned branch.
 - **D1:** CI runs on `push` with no paths filter; `validate` + `smoke-build` (the Docker target, `smoke: true`)
   run; `lint` runs markdownlint, cspell on README/HISTORY, actionlint; there is no unit-test or CSharpier/
   `dotnet format` step; the aggregator `needs:` both and blocks on non-success.
@@ -354,7 +355,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 | S2 | push changing only docs | `validate` (lint checks markdown) + `smoke-build` run; nothing publishes | D1, D1.5 |
 | S3 | push changing only `.github/workflows/**` | `smoke-build` exercises the changed reusable workflow head-resolved; `lint` runs actionlint; aggregator success | D1.1, D6.1 |
 | S4 | weekly `schedule` | builds + publishes `main` only: stable release + refreshed `latest` (multi-arch); `target_commitish` = main's SHA; develop is not touched | D4.1, D4.2, D4.4 |
-| S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.Z-g<sha>` + `develop` image; `github.ref` is develop, so NBGV (with `IGNORE_GITHUB_REF`) classifies it non-public | D4.1, D4.2, D3.2 |
+| S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.Z-g<sha>` + `develop` image; `github.ref` is develop, so NBGV classifies it non-public | D4.1, D4.2, D3.2 |
 | S6 | `workflow_dispatch` re-run, no new commits | release-create refreshed on dispatch (or skipped if the tag exists on schedule); Docker re-pushed (base refresh); no duplicate release | D4.5 |
 | S7 | `workflow_dispatch` from a feature branch | the `publish` job's `github.ref_name in (main, develop)` guard skips it -> no publish | D4.1 |
 | S8 | merged GitHub-Actions bump | not a shipped input and merges don't publish -> **no release**; ships in the next scheduled run | D4.1, D8.2 |

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -205,7 +205,7 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 - **D2.1 Validate before publishing.** Output: a dedicated job/step asserts each cross-input invariant and
   fails fast with `::error::` before a publish; downstream jobs `needs:` it.
-- **D2.2 Main matches version classification.** Input: a real (non-smoke) publish leg for `main`. Output: the
+- **D2.2 Main matches version classification.** Input: a real (non-smoke) publish run for `main`. Output: the
   release fails loudly if `main` carries a prerelease suffix. It strips `+buildmetadata` before testing for
   the prerelease `-`. Skipped on smoke. *Prevents a develop build published as the stable `latest`.*
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -118,7 +118,7 @@ main's. There is no definition-vs-content split to reason about.
 
 ### Versioning: compute once, thread everywhere
 
-NBGV runs once (in `get-version-task`), classifying from the checked-out branch, and its outputs (`SemVer2`,
+NBGV runs once (in `get-version-task`), classifying from `github.ref` (see below), and its outputs (`SemVer2`,
 `GitCommitId`) thread to every consumer via `outputs:` / `needs:`. The Docker build checks out a specific
 commit to build it, but consumes the threaded version. `main` (the public ref,
 `publicReleaseRefSpec = ^refs/heads/main$`) builds a clean `X.Y.<height>`; every other branch a prerelease
@@ -127,10 +127,10 @@ only `version.json` and git history, so it works although the repo builds no .NE
 
 NBGV classifies `publicReleaseRefSpec` from the `GITHUB_REF` environment variable. Because the publisher builds
 the **trigger ref** (one branch per run), `GITHUB_REF` already equals the branch being versioned - a schedule
-or `main` dispatch classifies as public (clean `X.Y.Z`), a `develop` dispatch as prerelease (`X.Y.Z-g<sha>`) -
-so no `GITHUB_REF` override is needed. (`GITHUB_REF` is reserved and cannot be reliably overridden anyway; the
-matrix publishers that build a non-trigger branch are the ones that need `IGNORE_GITHUB_REF`.) The main-version
-backstop (D2.2) catches any misclassification.
+or `main` dispatch classifies as public (clean `X.Y.<height>`), a `develop` dispatch as prerelease
+(`X.Y.<height>-g<sha>`) - so no `GITHUB_REF` override is needed. (`GITHUB_REF` is reserved and cannot be
+reliably overridden anyway; the matrix publishers that build a non-trigger branch are the ones that need
+`IGNORE_GITHUB_REF`.) The main-version backstop (D2.2) catches any misclassification.
 
 ### Validate at entry
 
@@ -215,8 +215,8 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 - **D3.1 NBGV runs once, threaded.** Output: NBGV runs once, classifying from the checked-out branch; no
   consumer re-invokes it. The run builds the trigger ref, so `GITHUB_REF` already matches the branch being
   versioned and NBGV classifies it correctly (no override needed).
-- **D3.2 `main` = stable, others = prerelease.** Output: `main` -> `X.Y.Z`, any other branch ->
-  `X.Y.Z-g<sha>`. The release-version backstop and the GitHub-release `prerelease` expression name `main`;
+- **D3.2 `main` = stable, others = prerelease.** Output: `main` -> `X.Y.<height>`, any other branch ->
+  `X.Y.<height>-g<sha>`. The release-version backstop and the GitHub-release `prerelease` expression name `main`;
   `publicReleaseRefSpec` is `^refs/heads/main$`.
 - **D3.3 Version floor + git height.** Output: `version.json` sets the major.minor floor, NBGV appends the
   git height as the patch, never bumped on a cadence. *(Who raises the floor and when is a human-process rule
@@ -355,7 +355,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 | S2 | push changing only docs | `validate` (lint checks markdown) + `smoke-build` run; nothing publishes | D1, D1.5 |
 | S3 | push changing only `.github/workflows/**` | `smoke-build` exercises the changed reusable workflow head-resolved; `lint` runs actionlint; aggregator success | D1.1, D6.1 |
 | S4 | weekly `schedule` | builds + publishes `main` only: stable release + refreshed `latest` (multi-arch); `target_commitish` = main's SHA; develop is not touched | D4.1, D4.2, D4.4 |
-| S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.Z-g<sha>` + `develop` image; `github.ref` is develop, so NBGV classifies it non-public | D4.1, D4.2, D3.2 |
+| S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.<height>-g<sha>` + `develop` image; `github.ref` is develop, so NBGV classifies it non-public | D4.1, D4.2, D3.2 |
 | S6 | `workflow_dispatch` re-run, no new commits | release-create refreshed on dispatch (or skipped if the tag exists on schedule); Docker re-pushed (base refresh); no duplicate release | D4.5 |
 | S7 | `workflow_dispatch` from a feature branch | the `publish` job's `github.ref_name in (main, develop)` guard skips it -> no publish | D4.1 |
 | S8 | merged GitHub-Actions bump | not a shipped input and merges don't publish -> **no release**; ships in the next scheduled run | D4.1, D8.2 |
@@ -369,7 +369,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 - After a `main` publish (schedule or dispatch) confirm a stable release (`isPrerelease == false`, tag plus
   `LICENSE` + `README.md`, no build asset) and a multi-arch `latest` + `:SemVer2`
   (`docker buildx imagetools inspect` shows amd64 + arm64) and the Docker Hub overview matching the root README;
-  after a `develop` dispatch confirm a prerelease `X.Y.Z-g<sha>` + `develop` image. A re-run adds no duplicate
+  after a `develop` dispatch confirm a prerelease `X.Y.<height>-g<sha>` + `develop` image. A re-run adds no duplicate
   release. Absent publish rights, record indeterminate and rely on 5A/5B.
 
 ### 5D. Configuration audit

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -18,12 +18,14 @@ Dockerfile is the only build input. Two workflows do the work:
 
 - **CI** runs on **push to every branch**: it validates (lint) and smoke-builds the image, publishing
   nothing. A pull request merges only when its required check is green.
-- **The publisher** runs on a **weekly schedule and on manual dispatch** - never on a merge. It builds and
-  publishes **both** `main` and `develop` in one run: `main` -> stable release + `latest` image, `develop`
-  -> prerelease + `develop` image. Merges accumulate; the next weekly run ships them, and the rebuild also
-  refreshes the `lscr.io/linuxserver/code-server` base for security updates.
+- **The publisher** runs on a **weekly schedule and on manual dispatch** - never on a merge, and builds **one
+  branch per run** (the trigger ref). The **schedule** rebuilds **`main` only** (stable release + refreshed
+  `latest` image, picking up base-image CVEs). A **dispatch** publishes the branch it is started from: from
+  `main` -> stable / `latest`, from `develop` -> prerelease / `develop`. Merges accumulate; the next scheduled
+  run ships main's, and a develop release is cut by dispatching from `develop`.
 
-There is no publish-on-merge and no per-push release. A maintainer dispatches to release on demand.
+There is no publish-on-merge, no per-push release, and no two-branch matrix - building only the trigger branch
+keeps `github.ref` aligned with the branch being versioned. A maintainer dispatches to release on demand.
 Dependabot pull requests merge themselves once their checks pass.
 
 ### Glossary
@@ -79,8 +81,8 @@ Legibility rules. Necessary but not sufficient: a perfectly styled workflow can 
   with the live ruleset.
 - **Concurrency.** Every entry workflow declares a `concurrency` group. CI uses
   `group: '${{ github.workflow }}-${{ github.ref }}'`, `cancel-in-progress: true`. The publisher overrides
-  it: a ref-independent group with `cancel-in-progress: false`, so publishes serialize (the run touches both
-  branches' shared Docker tags) and none is cancelled mid-release.
+  it: a ref-independent group with `cancel-in-progress: false`, so a `main` and a `develop` publish serialize
+  (they share the Docker Hub overview and registry) and none is cancelled mid-release.
 - **Shells.** Every multi-line bash `run:` starts with `set -euo pipefail`.
 - **Conditionals.** Multi-line `if:` uses the folded scalar `if: >-`.
 - **Boolean inputs.** A boolean used by both `workflow_call` and `workflow_dispatch` is declared in both
@@ -101,38 +103,33 @@ concurrency, so they never race. CI re-tests every pushed tree and never publish
 on its own cadence and never runs on push. *Prevents a merge from silently cutting a release, and a CI run
 from racing a publish on the same ref.*
 
-### The publisher is a two-branch matrix
+### The publisher builds one branch: the trigger ref
 
-A scheduled or dispatched publish builds **both** `main` and `develop` in one run via a matrix. Each leg is
-internally branch-scoped: it receives an explicit `ref` and `branch` input and checks out / versions / tags
-**that** branch, so the run's `github.ref_name` (always the default branch on a schedule) never leaks into a
-leg's classification. *Branch-derived config keys off `inputs.branch`, never `github.ref_name`.* This is the
-one place a single run touches two branches; the no-cross-branch rule (D0) is scoped to each leg, not the
-matrix.
+A publish builds exactly **one** branch - the run's trigger ref. The **schedule** always runs on the default
+branch, so it rebuilds `main`; a **dispatch** runs on the branch it is started from (`main` or `develop`). The
+single `publish` job passes `github.ref_name` as both `ref` and `branch`, so the branch built, versioned, and
+tagged is always the run's own ref. *No matrix and no cross-branch ref mixing - `github.ref` is the branch
+being published.* The job is guarded to the long-lived branches (`main` / `develop`); a stray dispatch from a
+feature branch is a no-op. To release `develop`, dispatch the workflow from `develop`.
 
-GitHub resolves a local `uses: ./...` reusable workflow from the **calling run's commit**, not from a leg's
-`ref` input - so on a schedule/dispatch (which runs from the default branch) **both** legs load the reusable
-task *definitions* from the default branch, while each leg's `ref`/`branch` inputs still drive its own
-checkout, version, image, and tag. A change to a workflow *definition* therefore only takes effect in the
-publisher once it reaches the default branch; the per-branch guarantee is over the built *content* (code,
-version, tag), not the orchestration YAML. (`uses:` does not accept an expression for the ref, so the legs
-cannot each load their own branch's definition.)
+Because the run's ref **is** the built branch, GitHub resolves the local `uses: ./...` reusable workflows from
+that same branch's commit - so a `develop` dispatch runs develop's own task definitions, and the schedule runs
+main's. There is no definition-vs-content split to reason about.
 
-### Versioning: compute once per leg, thread everywhere
+### Versioning: compute once, thread everywhere
 
-NBGV runs once per branch leg (in `get-version-task`), classifying from that leg's checkout, and its outputs
-(`SemVer2`, `GitCommitId`) thread to every consumer via `outputs:` / `needs:`. The Docker build checks out a
-specific commit to build it, but consumes the threaded version. `main` (the public ref,
+NBGV runs once (in `get-version-task`), classifying from the checked-out branch, and its outputs (`SemVer2`,
+`GitCommitId`) thread to every consumer via `outputs:` / `needs:`. The Docker build checks out a specific
+commit to build it, but consumes the threaded version. `main` (the public ref,
 `publicReleaseRefSpec = ^refs/heads/main$`) builds a clean `X.Y.<height>`; every other branch a prerelease
 `X.Y.<height>-g<sha>`. *Keeps the built image's version label and the release tag in agreement.* NBGV needs
 only `version.json` and git history, so it works although the repo builds no .NET assembly.
 
-NBGV matches `publicReleaseRefSpec` against the `GITHUB_REF` environment variable, **not** the checked-out
-HEAD. On the matrix publisher `GITHUB_REF` is always the dispatch/schedule ref (the default branch), which
-would misclassify the develop leg as a public release (a clean version, risking a `:SemVer2` Docker-tag
-collision with `main`). So `get-version-task` takes the leg's `branch` and pins
-`GITHUB_REF=refs/heads/<branch>` for the NBGV step, making each leg classify against its own branch. *Prevents
-the develop leg publishing a clean (non-prerelease) version.*
+NBGV classifies `publicReleaseRefSpec` from the `GITHUB_REF` environment variable, **not** the checked-out
+HEAD, and `GITHUB_REF` is reserved (a step `env:` cannot reliably override it - the runner re-injects the real
+ref). The nbgv step therefore sets `IGNORE_GITHUB_REF: "true"`, making NBGV ignore `GITHUB_REF` and classify
+from the **checked-out branch** - which here is always the published branch. *Prevents a develop build being
+classified as main's public (clean) version.* The main-version backstop (D2.2) catches any misclassification.
 
 ### Validate at entry
 
@@ -145,9 +142,9 @@ CI runs on push to every branch, so GitHub head-resolves the reusable `./...` wo
 a pull request that edits a reusable task tests its own copy. CI validates (the reusable `validate-task`:
 `lint` only - there is no compiled code) and smoke-builds the image, pushing nothing. One aggregator job, the
 ruleset-bound required check, gates the merge. A branch-deletion push (all-zeros `github.sha`) is skipped by a
-`!github.event.deleted` guard on every job, so a deletion never runs a failing build. Each publish leg runs
-`validate-task` against its own branch's checkout (the definition itself is resolved from the publisher's ref;
-see the matrix note above), so the publish gate applies the same lint steps to the branch being published.
+`!github.event.deleted` guard on every job, so a deletion never runs a failing build. The publisher runs the
+**same** `validate-task` against the branch it publishes (the run's ref is that branch), so the CI gate and the
+publish gate are the identical definition applied to the same tree.
 
 ### The single-target release
 
@@ -180,14 +177,13 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 - **D0.1 CI is one run, one branch.** Input: any push. Output: `test-pull-request` builds/validates exactly
   `github.ref_name` and publishes nothing. *Prevents cross-branch ref mixing in CI.*
-- **D0.2 The publisher leg is branch-scoped by input.** Output: each matrix leg checks out, versions, and
-  tags the branch named by its `ref`/`branch` inputs, never `github.ref_name`. The matrix builds both
-  branches; no leg builds a second branch. *Prevents the develop leg being classified as main (the run's
-  `github.ref_name` is `main` on a schedule).*
-- **D0.3 One version per leg, threaded.** Output: NBGV runs once per leg, every consumer reads it via
-  `needs:` outputs; no consumer recomputes it. *Allowed:* checking out a specific commit to build it, and
-  recording the built commit as the release `target_commitish`. *Prevents the image's version diverging from
-  its tag.*
+- **D0.2 The publisher builds one branch: the trigger ref.** Output: the `publish` job passes
+  `github.ref_name` as `ref` and `branch`, so it checks out, versions, and tags exactly the run's own branch
+  (the schedule's default branch, or a dispatch's branch). No matrix; the job is guarded to `main`/`develop`.
+  *Prevents cross-branch ref mixing - `github.ref` is the branch being published.*
+- **D0.3 One version, threaded.** Output: NBGV runs once, every consumer reads it via `needs:` outputs; no
+  consumer recomputes it. *Allowed:* checking out a specific commit to build it, and recording the built
+  commit as the release `target_commitish`. *Prevents the image's version diverging from its tag.*
 
 ### D1 - CI fast feedback
 
@@ -215,8 +211,9 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 ### D3 - Versioning and classification
 
-- **D3.1 NBGV per leg, threaded.** Output: NBGV runs once per leg, classifying from the leg's checkout; no
-  consumer re-invokes it.
+- **D3.1 NBGV runs once, threaded.** Output: NBGV runs once, classifying from the checked-out branch; no
+  consumer re-invokes it. The nbgv step sets `IGNORE_GITHUB_REF: "true"` so NBGV classifies from that branch,
+  not the reserved `GITHUB_REF` (which a dispatch run cannot reliably override).
 - **D3.2 `main` = stable, others = prerelease.** Output: `main` -> `X.Y.Z`, any other branch ->
   `X.Y.Z-g<sha>`. The release-version backstop and the GitHub-release `prerelease` expression name `main`;
   `publicReleaseRefSpec` is `^refs/heads/main$`.
@@ -228,14 +225,15 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 
 - **D4.1 Publish only on schedule or dispatch - never on push.** Output: `publish-release` triggers are
   `schedule` (weekly) and `workflow_dispatch` only. There is **no `push` trigger** and no `PUBLISH_ON_MERGE`
-  variable. A merge does not publish; a dispatch is guarded to the default branch (`main`), since the
-  workflow logic resolves from the dispatch ref. *Prevents per-merge release churn and a blind publish-on-merge.*
-- **D4.2 A publish builds both branches in full.** Output: the run matrices over `main` and `develop`; each
-  leg builds the Docker image and creates the GitHub release for its branch (`main` stable / `latest`,
-  `develop` prerelease / `develop`). *Prevents a half-published release set.*
-- **D4.3 Tag the built commit.** Output: the release `target_commitish` is the leg's `GitCommitId`, never
-  `github.sha` (which is the default branch's tip in the matrix). *Prevents the tag landing on the wrong
-  commit.*
+  variable. A merge does not publish. The job is guarded to `github.ref_name` in (`main`, `develop`), so a
+  stray dispatch from a feature branch is a no-op. *Prevents per-merge release churn and a blind
+  publish-on-merge.*
+- **D4.2 A publish builds the one trigger branch in full.** Output: the run builds the Docker image and
+  creates the GitHub release for `github.ref_name` - the schedule rebuilds `main` (stable / `latest`); a
+  dispatch publishes its own branch (`main` stable / `latest`, `develop` prerelease / `develop`). *Prevents a
+  half-published release and cross-branch ref mixing.*
+- **D4.3 Tag the built commit.** Output: the release `target_commitish` is the run's `GitCommitId` (the tip of
+  `github.ref_name`), never a moving branch ref. *Prevents the tag landing on the wrong commit.*
 - **D4.4 Release contents and flag.** Output: each release is a tag on the built commit (a version anchor)
   plus the auto-generated notes and the in-tree `LICENSE` + `README.md`; `fail_on_unmatched_files` catches a
   renamed/missing file. The GitHub-release `prerelease` boolean is `inputs.branch != 'main'`. No build
@@ -244,21 +242,18 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
   release-create step is skipped when the tag already exists (refreshed only on `workflow_dispatch`), while
   the Docker push still runs - re-pushing the same tags refreshes the base image. *Prevents duplicate releases
   while still refreshing the image.*
-- **D4.6 Publish is tested as built, per branch.** Output: each publish leg runs `validate-task` against its
-  own branch ref (inside `build-release-task`, gated `!smoke`) before building, so a failing lint on either
-  branch blocks only that leg. The reusable-task *definition* is resolved from the publisher's ref (the default
-  branch on a schedule; see the matrix note in section 3), so the lint *steps* are the default branch's applied
-  to the published branch's checkout - a workflow-definition change reaches the publisher once it lands on the
-  default branch. *Prevents publishing a tree that would fail the lint gate, including the leg whose branch is
-  not the run's trigger ref.*
+- **D4.6 Publish is tested as built.** Output: the publish runs `validate-task` against the branch it publishes
+  (inside `build-release-task`, gated `!smoke`) before building, so a failing lint blocks the release. The run's
+  ref **is** the published branch, so the reusable-task definitions resolve from that branch - it is the
+  identical definition CI runs on the same tree. *Prevents publishing a tree that would fail the lint gate.*
 - **D4.7 Docker publishing authenticates with Docker Hub credentials.** Output: the Docker target logs in via
   `docker/login-action` with `DOCKER_HUB_USERNAME` + `DOCKER_HUB_ACCESS_TOKEN` and pushes with
   `docker/build-push-action`; the Docker Hub overview is pushed with the same token. There is no NuGet/OIDC
   publishing in this repo. *Prevents a missing-credential publish failure.*
 - **D4.8 Branch-scoped Docker buildcache.** Output: the Docker build reads both branches' registry caches
-  (`buildcache-main`, `buildcache-develop`) and writes only its own branch's cache, only when pushing, so the
-  two matrix legs do not overwrite a shared cache. *Prevents the concurrent legs destroying each other's cache
-  hit-rate.*
+  (`buildcache-main`, `buildcache-develop`) and writes only its own branch's cache, only when pushing, so a
+  `main` and a `develop` publish never overwrite each other's cache. *Prevents one branch's publish destroying
+  the other's cache hit-rate.*
 
 ### D5 - Resource cleanup
 
@@ -325,8 +320,9 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 Read the workflow files plus `version.json` and assert the fact behind each applicable guarantee with a
 `file:line` citation:
 
-- **D0:** CI has no branch matrix; the publisher matrices over `main`/`develop` and every leg passes explicit
-  `ref`/`branch`; NBGV invoked once per leg, every other consumer reads it via `needs:`.
+- **D0:** CI has no branch matrix; the publisher's single `publish` job passes `github.ref_name` as
+  `ref`/`branch` and is guarded to `main`/`develop`; NBGV invoked once, every other consumer reads it via
+  `needs:`; the nbgv step sets `IGNORE_GITHUB_REF: "true"`.
 - **D1:** CI runs on `push` with no paths filter; `validate` + `smoke-build` (the Docker target, `smoke: true`)
   run; `lint` runs markdownlint, cspell on README/HISTORY, actionlint; there is no unit-test or CSharpier/
   `dotnet format` step; the aggregator `needs:` both and blocks on non-success.
@@ -334,8 +330,9 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 - **D3:** `main` appears in the backstop and the `prerelease` expression; `publicReleaseRefSpec` is
   `^refs/heads/main$`.
 - **D4:** `publish-release` triggers are `schedule` + `workflow_dispatch` only (no `push`, no
-  `PUBLISH_ON_MERGE`); it matrices both branches; each leg's `target_commitish` is `GitCommitId`; the
-  `prerelease` boolean `== (inputs.branch != 'main')`; the release attaches `LICENSE` + `README.md` with
+  `PUBLISH_ON_MERGE`); the single `publish` job is guarded to `github.ref_name` in (`main`, `develop`) and
+  passes it as `ref`/`branch`; `target_commitish` is `GitCommitId`; the `prerelease` boolean
+  `== (inputs.branch != 'main')`; the release attaches `LICENSE` + `README.md` with
   `fail_on_unmatched_files: true` and no build artifact; the Docker job logs in with `DOCKER_HUB_*` and pushes
   `latest`/`develop` + `:SemVer2`; release-create gated `exists == false || workflow_dispatch`; Docker
   buildcache is branch-scoped and write-gated on push; the Docker Hub overview push is gated to `main`.
@@ -356,22 +353,23 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 | S1 | push touching `Dockerfile` | `validate` + `smoke-build` run; the image builds, **no push, no release**; aggregator success | D0.1, D1 |
 | S2 | push changing only docs | `validate` (lint checks markdown) + `smoke-build` run; nothing publishes | D1, D1.5 |
 | S3 | push changing only `.github/workflows/**` | `smoke-build` exercises the changed reusable workflow head-resolved; `lint` runs actionlint; aggregator success | D1.1, D6.1 |
-| S4 | weekly `schedule` | both branches build + publish: main stable + `latest`, develop prerelease + `develop`; each leg `target_commitish` = its built SHA; Docker multi-arch pushed | D4.1, D4.2, D4.4 |
-| S5 | `workflow_dispatch` | same as S4 (force a release now); an already-released tag is refreshed | D4.1, D4.5 |
-| S6 | weekly re-run, no new commits | release-create skipped (tag exists); Docker re-pushed (base refresh); no duplicate release | D4.5 |
-| S7 | a develop leg would classify as main (e.g. `github.ref_name` leaked) | the leg versions from its own `ref`, so develop stays prerelease; the main backstop would fail a real mis-classification | D0.2, D2.2 |
-| S8 | merged GitHub-Actions bump | not a shipped input and merges don't publish -> **no release**; ships in the next weekly run | D4.1, D8.2 |
+| S4 | weekly `schedule` | builds + publishes `main` only: stable release + refreshed `latest` (multi-arch); `target_commitish` = main's SHA; develop is not touched | D4.1, D4.2, D4.4 |
+| S5 | `workflow_dispatch` from `develop` | builds + publishes `develop`: prerelease `X.Y.Z-g<sha>` + `develop` image; `github.ref` is develop, so NBGV (with `IGNORE_GITHUB_REF`) classifies it non-public | D4.1, D4.2, D3.2 |
+| S6 | `workflow_dispatch` re-run, no new commits | release-create refreshed on dispatch (or skipped if the tag exists on schedule); Docker re-pushed (base refresh); no duplicate release | D4.5 |
+| S7 | `workflow_dispatch` from a feature branch | the `publish` job's `github.ref_name in (main, develop)` guard skips it -> no publish | D4.1 |
+| S8 | merged GitHub-Actions bump | not a shipped input and merges don't publish -> **no release**; ships in the next scheduled run | D4.1, D8.2 |
 | S9 | PR with a markdown / spelling / workflow-YAML violation | the `lint` job fails -> aggregator blocks the merge | D1.3, D1.5 |
-| S10 | `version.json` floor bump merged | merges don't publish -> no immediate release; the new floor ships in the next weekly publish | D3.3, D4.1 |
-| S11 | `develop` -> `main` promotion (merge commit) | the merge itself does not publish; `main`'s accumulated changes ship in the next weekly run | D4.1, D8.1 |
+| S10 | `version.json` floor bump merged | merges don't publish -> no immediate release; the new floor ships in the next publish | D3.3, D4.1 |
+| S11 | `develop` -> `main` promotion (merge commit) | the merge itself does not publish; `main`'s accumulated changes ship in the next scheduled run | D4.1, D8.1 |
 
 ### 5C. Live probe (where warranted, never publishing)
 
 - Open a trivial-change PR and confirm S1 (the image smoke-builds, nothing pushed, aggregator green).
-- After a real publish, confirm both GitHub releases exist with the expected `isPrerelease` (each a tag plus
-  `LICENSE` + `README.md`, no build asset), the Docker tags are multi-arch
-  (`docker buildx imagetools inspect` shows amd64 + arm64), the Docker Hub overview matches the root README,
-  and a re-run added no duplicate release. Absent publish rights, record indeterminate and rely on 5A/5B.
+- After a `main` publish (schedule or dispatch) confirm a stable release (`isPrerelease == false`, tag plus
+  `LICENSE` + `README.md`, no build asset) and a multi-arch `latest` + `:SemVer2`
+  (`docker buildx imagetools inspect` shows amd64 + arm64) and the Docker Hub overview matching the root README;
+  after a `develop` dispatch confirm a prerelease `X.Y.Z-g<sha>` + `develop` image. A re-run adds no duplicate
+  release. Absent publish rights, record indeterminate and rely on 5A/5B.
 
 ### 5D. Configuration audit
 


### PR DESCRIPTION
Replaces the two-branch matrix publisher with one branch per run, and fixes the develop versioning by simplifying the model rather than adding an override.

## Publisher: one branch per run

- **schedule** -> rebuild **main only** (stable release + refreshed `latest` for base-image CVEs), straight from GitHub's context (`github.ref` is `main` on a schedule)
- **dispatch** -> publish the branch it is started from (`main` -> stable/`latest`, `develop` -> prerelease/`develop`); guarded to `main`/`develop`

No matrix and no `ref:` switching: the run builds its own trigger ref, so `github.ref` already equals the branch being built and versioned.

## NBGV classification

NBGV keys `publicReleaseRefSpec` off the `GITHUB_REF` env var. Because each run builds its **trigger ref**, `GITHUB_REF` already matches the branch being versioned, so NBGV classifies correctly with **no override**: a schedule / `main` dispatch -> clean `X.Y.<height>`, a `develop` dispatch -> `X.Y.<height>-g<sha>`.

`get-version-task` therefore sets **no** env: it does not override `GITHUB_REF` (which is reserved/read-only - an earlier override attempt was a no-op) and it does not set `IGNORE_GITHUB_REF` (that is only needed by a *matrix* publisher that builds a non-trigger branch). The `branch` input and its threading are reverted. The main-version backstop (D2.2) catches any misclassification.

## Docs

WORKFLOW.md's publisher model (section 0, architecture, D0/D3/D4, 5A audit, 5B scenarios), AGENTS.md Release Model, and the task headers/comments are rewritten to the one-branch-per-run shape.

## Verification

actionlint, markdownlint, YAML parse clean. After merge + promote, a `develop` dispatch publishes the `-g` prerelease and a `main` schedule/dispatch publishes stable.
