### PR TITLE
Promote: diagram-intro wording polish

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -173,7 +173,7 @@ tracker. A person steps in only for a breaking change (a red check) or to dispat
 ### Flow diagrams
 
 Three diagrams trace the architecture above: the pull-request gate, the scheduled/dispatched publisher, and
-the bot automation. They are the same outcomes section 4 contracts, drawn from the workflow YAML; if a
+the bot automation. They depict the same outcomes that the section 4 contract specifies, drawn from the workflow YAML; if a
 diagram and a guarantee disagree, one of them is a defect. Triggers are blue, gates yellow,
 durable/published outputs green, and stop/skip outcomes red.
 


### PR DESCRIPTION
Promote the diagram-intro reword (and HA's comment tightening) to main. One-sentence doc change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)