### PR TITLE
Address filed configuration and doc defects

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -374,7 +374,7 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 - **D7.1 The publisher does not cancel mid-flight.** Output: ref-independent group, `cancel-in-progress:
   false`. CI uses the `...-${{ github.ref }}` group with `cancel-in-progress: true`; the merge-bot keys on PR
   number (D8.1).
-- **D7.2 Skipped jobs still need valid permissions.** Output: every reusable job declares valid
+- **D7.2 Skipped jobs still need valid permissions.** Output: every reusable job runs under valid least-privilege
   `permissions:`; a callee's extra scope is granted by the caller.
 - **D7.3 Boolean inputs both forms.** Declared in both trigger blocks, compared against `true` and `'true'`.
 

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -138,7 +138,7 @@ check_security() {
   # 404 when disabled; automated-security-fixes returns { "enabled": true/false }.
   assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$REPO/vulnerability-alerts"
   assert "Dependabot automated security updates enabled" \
-    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes" 2>/dev/null)
+    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes")
 }
 
 check_secrets() {


### PR DESCRIPTION
- configure.sh: drop 2>/dev/null in check_security so gh's error surfaces (matches check_secrets).
- WORKFLOW.md D7.2: reword so it no longer claims reusable tasks *declare* permissions.

Closes #59

Validation: shellcheck + actionlint + markdownlint clean; line endings preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)