### PR TITLE
Migrate Docker Hub readme publisher to template task + resync drift

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,3 +150,5 @@ After the final push, sweep-resolve stale older threads for removed code paths.
 ## When in Doubt
 
 Read [AGENTS.md](../AGENTS.md) for this repo's conventions. For code-style rules, [`CODESTYLE.md`](../CODESTYLE.md) is authoritative. Don't restate any of these files' rules in commit bodies or PR descriptions - keep those focused on the change itself.
+
+**In a derived repo:** if you find a discrepancy that should be fixed in the template itself (this file or AGENTS.md is out of date, a rule is missing, something bit this repo and would bite the next), open an issue upstream in [`ptr727/ProjectTemplate`](https://github.com/ptr727/ProjectTemplate) rather than only fixing it locally - see the template's [AGENTS.md "Staying in Sync and Reporting Drift Upstream"](https://github.com/ptr727/ProjectTemplate/blob/main/AGENTS.md#staying-in-sync-and-reporting-drift-upstream).

--- a/.github/workflows/build-docker-task.yml
+++ b/.github/workflows/build-docker-task.yml
@@ -1,13 +1,14 @@
 name: Build Docker image task
 
-# Builds the multi-arch image (linux/amd64,arm64) and, on a main publish, pushes it plus the Docker Hub overview.
+# Builds the multi-arch image (linux/amd64,arm64) and pushes it on any publish (main or develop). The Docker Hub
+# overview is published separately, main-only, by publish-docker-readme-task.yml.
 # Branch drives the moving tag: main => `latest`, else `develop`, plus the `:SemVer2` tag. Smoke builds amd64 only
 # and never pushes; registry buildcache is branch-scoped. The orchestrator passes `branch` explicitly (the
 # publisher builds one branch per run - the trigger ref - and smoke passes github.ref_name).
 on:
   workflow_call:
     inputs:
-      # Push the built image and the Docker Hub overview.
+      # Push the built image.
       push:
         required: false
         type: boolean
@@ -83,13 +84,3 @@ jobs:
           cache-to: ${{ inputs.push && format('type=registry,ref=docker.io/ptr727/vscode-server-dotnetcore:buildcache-{0},mode=max,ignore-error=true', inputs.branch) || '' }}
           build-args: |
             LABEL_VERSION=${{ inputs.semver2 }}
-
-      # Push the Docker Hub overview from README.md, main only (one overview, no per-branch context).
-      - name: Update Docker Hub description step
-        if: ${{ inputs.push && inputs.branch == 'main' }}
-        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          repository: ptr727/vscode-server-dotnetcore
-          readme-filepath: ./README.md

--- a/.github/workflows/publish-docker-readme-task.yml
+++ b/.github/workflows/publish-docker-readme-task.yml
@@ -1,0 +1,34 @@
+name: Publish Docker Hub readme task
+
+on:
+  workflow_call:
+    inputs:
+      # Logical branch this run is for. The overview only updates on `main`;
+      # the publisher passes the branch so a develop leg is a no-op.
+      branch:
+        required: true
+        type: string
+
+jobs:
+
+  publish-docker-readme:
+    name: Publish Docker Hub readme job
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout code step
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Check out the branch being published so the main leg pushes main's readme regardless of the triggering ref.
+          ref: ${{ inputs.branch }}
+
+      # Push Docker/README.md as the Docker Hub repository overview, main only (one overview, no per-branch context).
+      - name: Publish Docker Hub readme step
+        if: ${{ inputs.branch == 'main' }}
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          repository: ptr727/vscode-server-dotnetcore
+          readme-filepath: ./Docker/README.md

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -41,3 +41,16 @@ jobs:
       smoke: false
       github: true
       dockerhub: true
+
+  # main-only: push the Docker Hub repository overview after a successful publish. One overview, no per-branch
+  # context, so a develop dispatch is a no-op; the task self-gates to main too.
+  docker-readme:
+    name: Publish Docker Hub readme job
+    needs: [publish]
+    if: ${{ github.ref_name == 'main' }}
+    uses: ./.github/workflows/publish-docker-readme-task.yml
+    secrets: inherit
+    permissions:
+      contents: read
+    with:
+      branch: ${{ github.ref_name }}

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,30 @@
+# VSCode Server with .NET Pre-Installed
+
+Docker image of [Code-Server](https://github.com/coder/code-server) with the .NET SDKs pre-installed, based on the [LinuxServer.io Code-Server][linuxserver-code-server] image.
+
+## License
+
+Licensed under the [MIT License](https://github.com/ptr727/VSCode-Server-DotNetCore/blob/main/LICENSE).
+
+![GitHub License](https://img.shields.io/github/license/ptr727/VSCode-Server-DotNetCore)
+
+## Project
+
+Code and pipeline are on [GitHub](https://github.com/ptr727/VSCode-Server-DotNetCore). Docker images are published on [Docker Hub](https://hub.docker.com/r/ptr727/vscode-server-dotnetcore). Images are rebuilt weekly and on demand, picking up the latest upstream Code-Server and .NET SDK updates.
+
+## Docker Tags
+
+- `latest`: Latest `main` branch build.
+- `develop`: Latest `develop` branch build.
+- `<version>`: Specific `SemVer2` version (e.g. `1.1.0`).
+
+## Platform Support
+
+- `linux/amd64`
+- `linux/arm64`
+
+## Usage
+
+Refer to the [GitHub README](https://github.com/ptr727/VSCode-Server-DotNetCore#usage) and the [linuxserver/code-server][linuxserver-code-server] documentation for configuration and environment variables.
+
+[linuxserver-code-server]: https://github.com/linuxserver/docker-code-server

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -342,7 +342,8 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
   identical definition CI runs on the same tree. *Prevents publishing a tree that would fail the lint gate.*
 - **D4.7 Docker publishing authenticates with Docker Hub credentials.** Output: the Docker target logs in via
   `docker/login-action` with `DOCKER_HUB_USERNAME` + `DOCKER_HUB_ACCESS_TOKEN` and pushes with
-  `docker/build-push-action`; the Docker Hub overview is pushed with the same token. There is no NuGet/OIDC
+  `docker/build-push-action`. The Docker Hub repository overview is published separately, main-only, by
+  `publish-docker-readme-task.yml` from `Docker/README.md` using the same credentials. There is no NuGet/OIDC
   publishing in this repo. *Prevents a missing-credential publish failure.*
 - **D4.8 Branch-scoped Docker buildcache.** Output: the Docker build reads both branches' registry caches
   (`buildcache-main`, `buildcache-develop`) and writes only its own branch's cache, only when pushing, so a
@@ -397,8 +398,8 @@ Each is a **MUST**, stated as input -> output plus the failure it prevents.
 - **D9.3** Bash `run:` blocks start `set -euo pipefail`; multi-line `if:` uses `>-`.
 - **D9.4** Line endings follow `.editorconfig`.
 - **D9.5 No decorative / dropped workflows.** No date-badge (`build-datebadge-*`), no tool-versions task, no
-  separate docker-readme task, no executable/`build-executable-task`, no `PUBLISH_ON_MERGE` variable, no
-  `dorny/paths-filter`. Their presence is a defect to remove.
+  executable/`build-executable-task`, no `PUBLISH_ON_MERGE` variable, no `dorny/paths-filter`. Their presence
+  is a defect to remove.
 - **D9.6** Style is enforced in CI by the `lint` job (D1.3), from the same config files the editor uses.
 
 ### D10 - Repository configuration
@@ -435,8 +436,8 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 - **D7:** the publisher group is ref-independent with `cancel-in-progress: false`; the merge-bot keys on PR
   number; CI uses the standard group; reusable jobs declare permissions.
 - **D8/D9:** the merge-bot runs on `pull_request_target` with the App token, keyed on PR number; Dependabot
-  auto-merge has no semver-major exception; no codegen/upstream-version, date-badge, tool-versions,
-  docker-readme task, executable task, `PUBLISH_ON_MERGE`, or `dorny/paths-filter`; actions SHA-pinned;
+  auto-merge has no semver-major exception; no codegen/upstream-version, date-badge, tool-versions, executable
+  task, `PUBLISH_ON_MERGE`, or `dorny/paths-filter`; actions SHA-pinned;
   names/shells/conditionals per section 2.
 
 ### 5B. End-to-end trace scenarios (deterministic from the YAML)
@@ -460,7 +461,7 @@ Read the workflow files plus `version.json` and assert the fact behind each appl
 - Open a trivial-change PR and confirm S1 (the image smoke-builds, nothing pushed, aggregator green).
 - After a `main` publish (schedule or dispatch) confirm a stable release (`isPrerelease == false`, tag plus
   `LICENSE` + `README.md`, no build asset) and a multi-arch `latest` + `:SemVer2`
-  (`docker buildx imagetools inspect` shows amd64 + arm64) and the Docker Hub overview matching the root README;
+  (`docker buildx imagetools inspect` shows amd64 + arm64) and the Docker Hub overview matching `Docker/README.md`;
   after a `develop` dispatch confirm a prerelease `X.Y.<height>-g<sha>` + `develop` image. A re-run adds no duplicate
   release. Absent publish rights, record indeterminate and rely on 5A/5B.
 

--- a/cspell.json
+++ b/cspell.json
@@ -2,6 +2,7 @@
   "version": "0.2",
   "language": "en-US",
   "words": [
+    "dockerhub",
     "dotnetcore",
     "linuxserver",
     "LSIO",


### PR DESCRIPTION
Closes #48

Resolves the remaining items of the template re-sync (#48): adopt the standardized Docker Hub readme publisher and carry the last verbatim doc paragraph.

## Docker Hub readme migration
Replaces the bespoke `peter-evans/dockerhub-description` step (buried in `build-docker-task.yml`, reading the root `README.md`) with the template's standardized approach:
- **New** `.github/workflows/publish-docker-readme-task.yml` - reusable, self-gated to `main`, reads `Docker/README.md`, uses `DOCKER_HUB_USERNAME` / `DOCKER_HUB_ACCESS_TOKEN` (already this repo's secret names - **nothing maintainer-gated**). Checkout pin aligned to the repo's existing `actions/checkout@…v7.0.0`.
- **New** `Docker/README.md` - a curated Docker Hub overview (trimmed from the GitHub README, per the template/ESPHome convention).
- `publish-release.yml` - new `docker-readme` job, `needs: [publish]`, `if: main`, `secrets: inherit`.
- `build-docker-task.yml` - remove the inline `dockerhub-description` step; fix the two now-stale comments.
- `WORKFLOW.md` - update D4.7, D9.5 (no longer "no docker-readme task"), the D8/D9 summary, and the verification checklist (overview now sourced from `Docker/README.md`).
- Root `README.md` is **kept** (still shipped by the GitHub-release step).

## Doc resync
- `.github/copilot-instructions.md` - append the template's verbatim **"In a derived repo:"** upstream-drift paragraph.
- `cspell.json` - add `dockerhub`.

Validated: `actionlint` (3 workflows), `markdownlint`, `cspell` all clean; new files are CRLF.

`Closes #48` targets `develop`; it fires on the `develop -> main` promotion.