### PR TITLE
Fix WORKFLOW.md overview description missed in the Docker readme migration

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -153,8 +153,8 @@ publish gate are the identical definition applied to the same tree.
 pushes multi-arch tags straight to Docker Hub (`latest` for main, `develop` for develop, plus `:SemVer2`). The
 GitHub release is a **version anchor**: it tags the built commit and attaches the in-tree `LICENSE` +
 `README.md` (no build artifact - the image ships to Docker Hub, not the release). The Docker Hub repository
-overview (the root [`README.md`](./README.md)) is pushed on a `main` Docker publish, since Docker Hub does not
-read the GitHub README.
+overview is published separately, main-only, from [`Docker/README.md`](./Docker/README.md) by
+`publish-docker-readme-task.yml`, since Docker Hub does not read the GitHub README.
 
 ### Resource lifecycle
 


### PR DESCRIPTION
Follow-up to #71 (flagged by Copilot on promotion #72): the architecture narrative (single-target release section) still described the Docker Hub overview as the root `README.md` pushed during the main Docker publish. It is now published separately, main-only, from `Docker/README.md` by `publish-docker-readme-task.yml`. Doc-only; targets `develop`; promotion #72 carries it.