### PR TITLE
Re-vendor the carried hub files to the current canonical

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,10 +1,13 @@
 {
     "config": {
-        // Prose paragraphs and data-heavy tables/URLs are intentionally long;
-        // reflowing at 80 cols hurts readability and churns diffs.
+        // Prose paragraphs and data-heavy tables or URLs are intentionally long.
+        // Reflowing at 80 columns hurts readability and churns diffs.
         "MD013": false,
-        // Inline HTML is used for reference-link section dividers.
-        "MD033": false,
+        // MD033 (inline HTML) stays enabled so native markdown wins.
+        // HTML comments, used as reference-link dividers, pass it.
+        // The details and summary elements are allowed for GitHub collapsibles, which have no markdown equivalent.
+        // Every other element still flags.
+        "MD033": { "allowed_elements": ["details", "summary"] },
         // Require fenced code blocks over the legacy 4-space-indented style.
         "MD046": { "style": "fenced" },
         // MD060 (table column style) is not enforced - allow both compact

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -1,265 +1,193 @@
 #!/usr/bin/env bash
-# Configure or validate a repository against the committed fleet config in this directory, via the GitHub API.
+# Repository configuration as code - the secrets, branch rulesets, and settings the workflows assume
+# (see WORKFLOW.md section 6, guarantee D10). Idempotent: `apply` configures a repo to match the JSON in
+# this directory; `check` validates an existing repo and exits non-zero on drift (the 5D audit). Run from
+# anywhere; the target repo is resolved from the current `gh` context unless $REPO is set (owner/name).
 #
-#   Apply:  repo-config/configure.sh apply [owner/repo] [release|operational]   # create-or-update settings + rulesets (writes)
-#   Check:  repo-config/configure.sh check [owner/repo] [release|operational]   # validate an existing repo, non-zero on drift (reads)
+#   ./repo-config/configure.sh check     # validate only, no writes (the 5D audit)
+#   ./repo-config/configure.sh apply     # create-or-update rulesets + settings (writes)
 #
-# Both modes need admin on the repo, because the rulesets endpoints require it.
-# The command defaults to apply, the repo to the current gh repo, and the model to the registry lookup.
-# With no registry to consult, the model is inferred from the carried develop payload.
-# The model may be passed as the sole positional, as in `configure.sh check operational`.
-# The command may be omitted for the apply default, so `configure.sh owner/repo` still applies.
-#
-# The apply mode writes three groups, in order.
-# First settings.json via PATCH, plus has_discussions (public repos only) and default_branch (main, only when it exists).
-# Then the Dependabot vulnerability alerts and automated security updates.
-# Then the branch rulesets, main.json shared and the model-specific develop ruleset, create-or-update by name.
-# The develop ruleset is develop.json where the model is PR-gated, or operational/develop.json for direct signed pushes.
-# Applying the same configuration twice changes nothing, so the mode is idempotent.
-#
-# The check mode is the read-only inverse, where every applied ruleset, setting, and security feature must match.
-# The ruleset and settings assertions are driven by the committed payloads, so they stay repo-agnostic.
-# That also survives the GitHub API normalizing a stored ruleset, comparing rule presence, merge methods and required checks rather than a byte diff.
-# Secrets are per-repo (see spec/secrets.json) and not checkable from a standalone carry, so they are a manual-verify note.
-set -Eeuo pipefail
+# Requires gh and jq. Both modes read the rulesets and secrets endpoints, which need admin on the repo, so
+# gh must be authenticated with admin for `check` as well as `apply`. `check` only reads; `apply` writes.
 
-# ----- Command + target + model -----
-cmd=apply
-case "${1:-}" in apply|check) cmd="$1"; shift ;; esac
-repo_arg="${1:-}"
-model="${2:-}"
-# Allow the model as the sole positional (`configure.sh check operational`): a model name is not a repo.
-case "$repo_arg" in release|operational) model="$repo_arg"; repo_arg="" ;; esac
-repo="${repo_arg:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -euo pipefail
 
-# ----- Resolve the workflow model (selects the develop ruleset), shared by apply and check -----
-registry="$script_dir/../registry/repos.json"
-name="${repo##*/}"
-if [ -z "$model" ]; then
-    if [ -f "$registry" ]; then
-        # Fail fast on a jq or parse error (a malformed registry) rather than silently applying the release default.
-        # Silently defaulting would hide a lookup that actually broke.
-        # A repo simply absent from the registry is not an error.
-        # The expression falls back through defaults.workflowModel to "release", so jq still exits 0 with a value.
-        if ! model="$(jq -r --arg n "$name" '(.repos[] | select(.name==$n) | .workflowModel) // .defaults.workflowModel // "release"' "$registry")"; then
-            echo "Failed to read workflowModel from $registry (invalid JSON?). Pass the model explicitly (release|operational)." >&2
-            exit 1
-        fi
-    else
-        # With no registry to consult (a downstream carry), infer the model from which develop payload is carried.
-        # A carry holds exactly its own model's payload.
-        # An ambiguous layout (both or neither, as in a partial copy) aborts rather than guesses.
-        # A wrong guess would apply or check the wrong develop ruleset.
-        if [ -f "$script_dir/develop.json" ] && [ ! -f "$script_dir/operational/develop.json" ]; then
-            model="release"
-        elif [ -f "$script_dir/operational/develop.json" ] && [ ! -f "$script_dir/develop.json" ]; then
-            model="operational"
-        else
-            echo "Registry $registry not found and the carried develop payloads are ambiguous (expected exactly one of develop.json or operational/develop.json). Pass the model explicitly (release|operational)." >&2
-            exit 1
-        fi
-        echo "Registry $registry not found. Inferred workflow model '$model' from the carried develop payload." >&2
-    fi
-fi
-case "$model" in
-    release) develop_ruleset="$script_dir/develop.json" ;;
-    operational) develop_ruleset="$script_dir/operational/develop.json" ;;
-    *) echo "Unknown workflow model '$model' (expected release or operational)." >&2; exit 1 ;;
-esac
-main_ruleset="$script_dir/main.json"
-settings_file="$script_dir/settings.json"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
-# ----- Ruleset id lookup (shared by apply and check) -----
-# Map a ruleset name to the id of the first match, leaving it empty when nothing matches.
-# It warns on duplicates, and aborts on an API error or at the per_page cap, where a single-fetch lookup is unreliable.
-ruleset_id() {
-    local out ids count
-    # Requesting per_page=100 returns every ruleset in one array, since a repo carries only a handful.
-    # The response is then a single JSON document, where a paginated fetch would concatenate arrays and break the jq below.
-    # Let gh print its own error on stderr.
-    # Add a context line and return non-zero, so the caller stops rather than treat an API failure as "not found".
-    if ! out="$(gh api "repos/$repo/rulesets?per_page=100")"; then
-        echo "Failed to list rulesets for $repo (check auth and repo access)." >&2
-        return 1
-    fi
-    # Fail loud rather than silently narrow, because a full page means the single-fetch assumption no longer holds.
-    # A missed lookup would make apply create a duplicate ruleset by name.
-    # Abort so the caller stops, since it treats a non-zero return as "stop" and never as "not found".
-    if [ "$(jq 'length' <<<"$out")" -eq 100 ]; then
-        echo "Failed for $repo: 100 rulesets returned (the per_page cap), so the single-fetch lookup is unreliable. Reduce rulesets or add pagination before applying." >&2
-        return 1
-    fi
-    # shellcheck disable=SC2016  # $n is a jq --arg variable, not a shell expansion
-    ids="$(jq -r --arg n "$1" '.[] | select(.name==$n) | .id' <<<"$out")"
-    if [ -z "$ids" ]; then return 0; fi
-    # Pre-existing drift can leave more than one ruleset with the same name.
-    # Use the first and warn, so the duplicates get resolved rather than silently operating on the wrong one.
-    # Both grep -c and sed read all their input with no early pipe close, so neither SIGPIPEs jq under pipefail.
-    count="$(printf '%s\n' "$ids" | grep -c .)"
-    if [ "$count" -gt 1 ]; then
-        echo "Warning: $count rulesets named '$1' on $repo. Using the first (resolve the duplicates)." >&2
-    fi
-    printf '%s\n' "$ids" | sed -n '1p'
+# Secrets by store (names only; values are never readable via the API). The Docker Hub credentials and the
+# merge-bot App credentials must be set in BOTH stores: a Dependabot-triggered run gets the Dependabot secret
+# store, not Actions secrets, and that run's push CI builds the Docker smoke, which logs in to Docker Hub.
+# Publishing the GitHub release uses the built-in GITHUB_TOKEN (no secret needed).
+REQUIRED_ACTIONS_SECRETS=(DOCKER_HUB_USERNAME DOCKER_HUB_ACCESS_TOKEN CODEGEN_APP_CLIENT_ID CODEGEN_APP_PRIVATE_KEY)
+REQUIRED_DEPENDABOT_SECRETS=(DOCKER_HUB_USERNAME DOCKER_HUB_ACCESS_TOKEN CODEGEN_APP_CLIENT_ID CODEGEN_APP_PRIVATE_KEY)
+REQUIRED_CHECK="Check pull request workflow status job"
+
+note()  { printf '  %s\n' "$*"; }
+pass()  { printf '  \033[32mok\033[0m   %s\n' "$*"; }
+fail()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILED=1; }
+FAILED=0
+
+ruleset_id() { # name -> id (empty if absent); aborts with a visible reason on an API error
+  local out
+  # An absent ruleset is a successful call with no match (empty); only a real API error fails. Let gh print its
+  # own error on stderr (do not suppress it); add a generic context line and return non-zero so the run stops
+  # (the caller's $(...) cannot print the cause itself).
+  # per_page=100 returns every ruleset in one array (a repo has only a handful); the default page size is 30.
+  if ! out="$(gh api "repos/$REPO/rulesets?per_page=100")"; then
+    echo "ERROR: could not list rulesets for $REPO (see gh error above)" >&2
+    return 1
+  fi
+  # shellcheck disable=SC2016  # $n is a jq variable (--arg n), not a shell expansion
+  # Select the first match inside jq (not `| head -1`): under pipefail, head closing the pipe early can
+  # SIGPIPE jq and fail the function.
+  jq -r --arg n "$1" '[.[] | select(.name==$n) | .id] | first // empty' <<<"$out"
 }
 
-# =============================== apply ===============================
-apply_ruleset() { # payload-file - create-or-update the ruleset by name
-    local file="$1" rname id
-    if [ ! -e "$file" ]; then
-        echo "Ruleset payload $file not found. Aborting to avoid a partially-applied configuration." >&2
-        exit 1
-    fi
-    rname="$(jq -r '.name // empty' "$file")"
-    if [ -z "$rname" ]; then
-        echo "Ruleset payload $file has no name. Aborting to avoid a partially-applied configuration." >&2
-        exit 1
-    fi
-    id="$(ruleset_id "$rname")"
-    if [ -n "$id" ]; then
-        echo "Updating ruleset '$rname' (id $id) on $repo"
-        gh api --method PUT "repos/$repo/rulesets/$id" --input "$file" >/dev/null
-    else
-        echo "Creating ruleset '$rname' on $repo"
-        gh api --method POST "repos/$repo/rulesets" --input "$file" >/dev/null
-    fi
+apply_ruleset() {
+  local file="$1" name id
+  name="$(jq -r .name "$file")"
+  id="$(ruleset_id "$name")"
+  if [[ -n "$id" ]]; then
+    gh api -X PUT "repos/$REPO/rulesets/$id" --input "$file" >/dev/null
+    note "updated ruleset '$name' (#$id)"
+  else
+    gh api -X POST "repos/$REPO/rulesets" --input "$file" >/dev/null
+    note "created ruleset '$name'"
+  fi
 }
 
 cmd_apply() {
-    local f private disc payload
-    # Pre-flight every required payload before any write, so a partial carry aborts before it half-applies.
-    for f in "$settings_file" "$develop_ruleset" "$main_ruleset"; do
-        if [ ! -e "$f" ]; then
-            echo "Required payload $f not found. Aborting to avoid a partially-applied configuration." >&2
-            exit 1
-        fi
-    done
-    echo "Applying configuration to $repo (model: $model)"
-    # The writes below silence stdout only, because the success-response JSON is noise.
-    # They still fail loud, since gh errors go to stderr and a failed write aborts the script.
-    # These writes run unguarded under `set -e`.
-    # ----- General repository settings -----
-    # Discussions are enabled on public repos only by fleet policy, and never on a private one.
-    private="$(gh api "repos/$repo" --jq '.private')"
-    disc=false; [ "$private" = "false" ] && disc=true
-    # The default branch is main, but only point it there once main exists.
-    # Never set the default to a missing branch, as on a repo still living on a rework branch.
-    if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
-        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d, default_branch: "main"}' "$settings_file")"
-    else
-        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d}' "$settings_file")"
-        echo "Warning: $repo has no 'main' branch. Leaving default_branch unchanged." >&2
-    fi
-    echo "Applying general settings (has_discussions=$disc)"
-    printf '%s' "$payload" | gh api --method PATCH "repos/$repo" --input - >/dev/null
-    # ----- Dependabot alerts + automated security updates -----
-    gh api --method PUT "repos/$repo/vulnerability-alerts" >/dev/null
-    gh api --method PUT "repos/$repo/automated-security-fixes" >/dev/null
-    echo "Enabled Dependabot vulnerability alerts + automated security updates"
-    # ----- Branch rulesets (main shared, develop selected by workflow model) -----
-    apply_ruleset "$develop_ruleset"
-    apply_ruleset "$main_ruleset"
-    echo "Configuration applied to $repo. Run '$0 check${repo_arg:+ $repo}' to validate."
+  echo "Applying repository configuration to $REPO"
+  apply_ruleset "$DIR/ruleset-develop.json"
+  apply_ruleset "$DIR/ruleset-main.json"
+  gh api -X PATCH "repos/$REPO" --input "$DIR/settings.json" >/dev/null
+  note "patched repository settings"
+  gh api -X PUT "repos/$REPO/vulnerability-alerts" >/dev/null
+  gh api -X PUT "repos/$REPO/automated-security-fixes" >/dev/null
+  note "enabled Dependabot alerts + security updates"
+  echo "Done. Run '$0 check' to validate."
 }
 
-# =============================== check ===============================
-FAILED=0
-note() { printf '  %s\n' "$*"; }
-pass() { printf '  ok   %s\n' "$*"; }
-fail() { printf '  FAIL %s\n' "$*"; FAILED=1; }
+# --- validation (5D) -------------------------------------------------------------------------------
 
-# Run a test command with `assert MESSAGE TEST...`, passing on success and failing on non-zero.
-# It is a proper if/else rather than the `A && B || C` footgun.
-# Do not redirect the assert call's own stdout, which would swallow the pass or fail line.
-# A command that prints, such as jq, goes through jq_has, which silences only itself.
-assert() { local msg="$1"; shift; if "$@"; then pass "$msg"; else fail "$msg"; fi; }
+# assert MESSAGE TEST... - run the test command; pass on success, fail on non-zero (proper if/else, not
+# the A && B || C footgun). The test command may read stdin (e.g. a `<<<` heredoc on the assert call).
+# Do not redirect the assert call's stdout - that would also swallow the pass/fail line; commands that
+# print (jq) use `jq_has`, which silences only itself.
+assert() {
+  local msg="$1"; shift
+  if "$@"; then pass "$msg"; else fail "$msg"; fi
+}
 
-# Test with `jq_has FILTER...`, which is true only when the filter selects a truthy value.
-# The jq output is discarded, not the caller's.
-# It reads its JSON from stdin.
+# jq_has FILTER... - true iff the jq filter selects something; jq's own output is discarded, not the
+# caller's. Reads JSON from stdin.
 jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
-# Test with `gh_ok ENDPOINT...`, which is true only when the gh api call succeeds, a 204 included.
-# Output and errors are both discarded, so it is safe to pass to assert.
-# The vulnerability-alerts endpoint is the example, returning 204 when enabled and 404 when disabled.
-gh_ok() { gh api "$@" >/dev/null 2>&1; }
+# jq_lacks FILTER... - true iff the jq filter yields no truthy value (selects nothing, or only false/null).
+# `jq -e` exits 1 (last output false/null) or 4 (no output at all) for the "lacks" cases, 0 for a truthy
+# match, and 2/3/5 for a real error (malformed filter or input), which is propagated so the calling assert
+# fails loudly. The `|| rc=$?` keeps jq in a list (exempt from set -e) so a non-zero exit captures rc instead
+# of aborting. Only stdout is discarded - jq's stderr is kept so a real error shows its diagnostic.
+jq_lacks() { local rc=0; jq -e "$@" >/dev/null || rc=$?; case "$rc" in 0) return 1 ;; 1|4) return 0 ;; *) return "$rc" ;; esac; }
 
-check_ruleset() { # payload-file - the live ruleset must match the committed policy, driven by the payload
-    local file="$1" rname id live t want got wantc gotc want_enf
-    if [ ! -e "$file" ]; then fail "ruleset payload $file missing"; return; fi
-    rname="$(jq -r '.name // empty' "$file")"
-    if [ -z "$rname" ]; then fail "ruleset payload $file has no name"; return; fi
-    if ! id="$(ruleset_id "$rname")"; then fail "ruleset '$rname' - could not resolve id"; return; fi
-    if [ -z "$id" ]; then fail "ruleset '$rname' missing"; return; fi
-    if ! live="$(gh api "repos/$repo/rulesets/$id")"; then fail "ruleset '$rname' - could not read live state"; return; fi
-    want_enf="$(jq -r '.enforcement' "$file")"
-    assert "ruleset '$rname' enforcement = $want_enf" test "$(jq -r '.enforcement' <<<"$live")" = "$want_enf"
-    # Every rule type the committed payload declares must be present live (payload-driven, so repo-agnostic).
-    while IFS= read -r t; do
-        # shellcheck disable=SC2016  # $t is a jq --arg variable, not a shell expansion
-        assert "'$rname' enforces rule '$t'" jq_has --arg t "$t" '.rules[] | select(.type==$t)' <<<"$live"
-    done < <(jq -r '.rules[].type' "$file")
-    # For pull_request, the live merge methods must match the payload, which is the develop=squash and main=merge policy.
-    if jq_has '.rules[] | select(.type=="pull_request")' "$file"; then
-        want="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' "$file")"
-        got="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' <<<"$live")"
-        assert "'$rname' merge methods = $want" test "$got" = "$want"
-    fi
-    # For required_status_checks, the live required contexts must match the payload.
-    if jq_has '.rules[] | select(.type=="required_status_checks")' "$file"; then
-        wantc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' "$file")"
-        gotc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' <<<"$live")"
-        assert "'$rname' required checks = $wantc" test "$gotc" = "$wantc"
-    fi
+check_ruleset() { # name  expected-merge-method  expect-linear(true/false)
+  local name="$1" method="$2" linear="$3" id rs
+  id="$(ruleset_id "$name")"
+  if [[ -z "$id" ]]; then fail "ruleset '$name' missing"; return; fi
+  rs="$(gh api "repos/$REPO/rulesets/$id")"
+  assert "ruleset '$name' active" \
+    test "$(jq -r '.enforcement' <<<"$rs")" = active
+  assert "'$name' merge method = $method" \
+    test "$(jq -r '.rules[] | select(.type=="pull_request") | .parameters.allowed_merge_methods | join(",")' <<<"$rs")" = "$method"
+  assert "'$name' requires signed commits" \
+    jq_has '.rules[] | select(.type=="required_signatures")' <<<"$rs"
+  assert "'$name' strict status policy off" \
+    test "$(jq -r '.rules[] | select(.type=="required_status_checks") | .parameters.strict_required_status_checks_policy' <<<"$rs")" = false
+  # shellcheck disable=SC2016  # $c is a jq variable (--arg c), not a shell expansion
+  assert "'$name' requires '$REQUIRED_CHECK'" \
+    jq_has --arg c "$REQUIRED_CHECK" '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[] | select(.context==$c)' <<<"$rs"
+  if [[ "$linear" == "true" ]]; then
+    assert "'$name' requires linear history" \
+      jq_has '.rules[] | select(.type=="required_linear_history")' <<<"$rs"
+  else
+    # main must NOT require linear history - it would block the develop -> main merge-commit promotion.
+    assert "'$name' does not require linear history" \
+      jq_lacks '.rules[] | select(.type=="required_linear_history")' <<<"$rs"
+  fi
 }
 
+# gh_ok ENDPOINT... - true iff the gh api call succeeds (2xx, including 204). Output and errors are
+# discarded, so it is safe to pass to `assert`.
+gh_ok() { gh api "$@" >/dev/null 2>&1; }
+
 check_settings() {
-    local live key want got private wantdisc
-    if [ ! -e "$settings_file" ]; then fail "settings payload $settings_file missing"; return; fi
-    if ! live="$(gh api "repos/$repo")"; then fail "could not read repository settings"; return; fi
-    # Static settings are driven from settings.json, so the check never drifts from the file.
-    # Add a key there and it is audited here automatically.
-    while IFS=$'\t' read -r key want; do
-        # shellcheck disable=SC2016  # $k is a jq --arg variable, not a shell expansion
-        got="$(jq -r --arg k "$key" '.[$k]' <<<"$live")"
-        assert "setting $key = $want" test "$got" = "$want"
-    done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$settings_file")
-    # Dynamic settings apply sets: has_discussions (public repos only), default_branch (main, if it exists).
-    private="$(jq -r '.private' <<<"$live")"
-    wantdisc=true; [ "$private" = "true" ] && wantdisc=false
-    assert "has_discussions = $wantdisc" test "$(jq -r '.has_discussions' <<<"$live")" = "$wantdisc"
-    if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
-        assert "default_branch = main" test "$(jq -r '.default_branch' <<<"$live")" = main
-    fi
+  local s; s="$(gh api "repos/$REPO")"
+  # Drive every assertion from settings.json, so the check covers exactly the applied desired state and
+  # never drifts from the file (add a key there and it is audited here automatically).
+  local key want got
+  while IFS=$'\t' read -r key want; do
+    # shellcheck disable=SC2016  # $k is a jq variable (--arg k), not a shell expansion
+    got="$(jq -r --arg k "$key" '.[$k]' <<<"$s")"
+    assert "setting $key = $want" test "$got" = "$want"
+  done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$DIR/settings.json")
 }
 
 check_security() {
-    local sec
-    # The vulnerability-alerts endpoint returns 204 when enabled and 404 when disabled, so probe it with gh_ok.
-    # The automated-security-fixes endpoint returns a JSON body of { enabled, paused }.
-    # That one is captured under an explicit failure guard, so a read error is a clean FAIL rather than a set -e abort.
-    assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$repo/vulnerability-alerts"
-    if sec="$(gh api "repos/$repo/automated-security-fixes" 2>/dev/null)"; then
-        assert "Dependabot automated security updates enabled" jq_has '.enabled == true' <<<"$sec"
-    else
-        fail "Dependabot automated security updates - could not read the setting"
-    fi
+  # apply enables both; audit that they are still on. vulnerability-alerts returns 204 when enabled and
+  # 404 when disabled; automated-security-fixes returns { "enabled": true/false }.
+  assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$REPO/vulnerability-alerts"
+  assert "Dependabot automated security updates enabled" \
+    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes")
+}
+
+check_secrets() {
+  # --paginate: the secrets endpoints page at 30, so without it a repo with many secrets could miss a
+  # required name and report a false failure. An API/auth error FAILs fast (the required secrets cannot be
+  # verified, so reporting "matches" would be wrong) - distinct from a genuinely missing secret, which also
+  # FAILs. gh prints its own error (stderr not suppressed) so the cause is actionable.
+  local actions deps
+  if ! actions="$(gh api --paginate "repos/$REPO/actions/secrets" --jq '.secrets[].name')"; then
+    fail "could not list Actions secrets (API error - cannot verify required secrets)"; return
+  fi
+  if ! deps="$(gh api --paginate "repos/$REPO/dependabot/secrets" --jq '.secrets[].name')"; then
+    fail "could not list Dependabot secrets (API error - cannot verify required secrets)"; return
+  fi
+  for s in "${REQUIRED_ACTIONS_SECRETS[@]}"; do
+    assert "actions secret $s present" grep -qx "$s" <<<"$actions"
+  done
+  for s in "${REQUIRED_DEPENDABOT_SECRETS[@]}"; do
+    assert "dependabot secret $s present" grep -qx "$s" <<<"$deps"
+  done
+}
+
+check_app() {
+  # Best-effort: confirm a GitHub App installation backs the merge-bot automation. A precise check
+  # requires app-level auth; presence of the App secrets above is the practical proxy.
+  if gh api "repos/$REPO/installation" >/dev/null 2>&1; then
+    pass "a GitHub App is installed on the repo"
+  else
+    note "could not confirm App installation via this token (verify the merge-bot App is installed)"
+  fi
 }
 
 cmd_check() {
-    echo "Validating configuration for $repo (model: $model)"
-    check_ruleset "$develop_ruleset"
-    check_ruleset "$main_ruleset"
-    check_settings
-    check_security
-    # Secrets are per-repo (spec/secrets.json) and not readable by value.
-    # A standalone carry has no registry to derive the required set from, so they are verified by hand rather than asserted here.
-    note "verify manually: the repo's required secrets (see spec/secrets.json) are present with valid values"
-    if [ "$FAILED" -ne 0 ]; then echo "Configuration drift detected on $repo."; exit 1; fi
-    echo "Configuration matches on $repo."
+  echo "Validating repository configuration for $REPO"
+  check_ruleset develop squash true
+  check_ruleset main   merge  false
+  check_settings
+  check_security
+  check_secrets
+  check_app
+  # Not checkable via gh api beyond name presence: that DOCKER_HUB_ACCESS_TOKEN is valid and has push
+  # access to docker.io/ptr727/vscode-server-dotnetcore. Verify it by hand in the Docker Hub account.
+  note "verify manually: Docker Hub access token valid with push to docker.io/ptr727/vscode-server-dotnetcore"
+  if [[ "$FAILED" -ne 0 ]]; then echo "Configuration drift detected."; exit 1; fi
+  echo "Configuration matches."
 }
 
-case "$cmd" in
-    apply) cmd_apply ;;
-    check) cmd_check ;;
+case "${1:-check}" in
+  apply) cmd_apply ;;
+  check) cmd_check ;;
+  *) echo "usage: $0 [apply|check]" >&2; exit 2 ;;
 esac

--- a/repo-config/configure.sh
+++ b/repo-config/configure.sh
@@ -1,193 +1,265 @@
 #!/usr/bin/env bash
-# Repository configuration as code - the secrets, branch rulesets, and settings the workflows assume
-# (see WORKFLOW.md section 6, guarantee D10). Idempotent: `apply` configures a repo to match the JSON in
-# this directory; `check` validates an existing repo and exits non-zero on drift (the 5D audit). Run from
-# anywhere; the target repo is resolved from the current `gh` context unless $REPO is set (owner/name).
+# Configure or validate a repository against the committed fleet config in this directory, via the GitHub API.
 #
-#   ./repo-config/configure.sh check     # validate only, no writes (the 5D audit)
-#   ./repo-config/configure.sh apply     # create-or-update rulesets + settings (writes)
+#   Apply:  repo-config/configure.sh apply [owner/repo] [release|operational]   # create-or-update settings + rulesets (writes)
+#   Check:  repo-config/configure.sh check [owner/repo] [release|operational]   # validate an existing repo, non-zero on drift (reads)
 #
-# Requires gh and jq. Both modes read the rulesets and secrets endpoints, which need admin on the repo, so
-# gh must be authenticated with admin for `check` as well as `apply`. `check` only reads; `apply` writes.
+# Both modes need admin on the repo, because the rulesets endpoints require it.
+# The command defaults to apply, the repo to the current gh repo, and the model to the registry lookup.
+# With no registry to consult, the model is inferred from the carried develop payload.
+# The model may be passed as the sole positional, as in `configure.sh check operational`.
+# The command may be omitted for the apply default, so `configure.sh owner/repo` still applies.
+#
+# The apply mode writes three groups, in order.
+# First settings.json via PATCH, plus has_discussions (public repos only) and default_branch (main, only when it exists).
+# Then the Dependabot vulnerability alerts and automated security updates.
+# Then the branch rulesets, main.json shared and the model-specific develop ruleset, create-or-update by name.
+# The develop ruleset is develop.json where the model is PR-gated, or operational/develop.json for direct signed pushes.
+# Applying the same configuration twice changes nothing, so the mode is idempotent.
+#
+# The check mode is the read-only inverse, where every applied ruleset, setting, and security feature must match.
+# The ruleset and settings assertions are driven by the committed payloads, so they stay repo-agnostic.
+# That also survives the GitHub API normalizing a stored ruleset, comparing rule presence, merge methods and required checks rather than a byte diff.
+# Secrets are per-repo (see spec/secrets.json) and not checkable from a standalone carry, so they are a manual-verify note.
+set -Eeuo pipefail
 
-set -euo pipefail
+# ----- Command + target + model -----
+cmd=apply
+case "${1:-}" in apply|check) cmd="$1"; shift ;; esac
+repo_arg="${1:-}"
+model="${2:-}"
+# Allow the model as the sole positional (`configure.sh check operational`): a model name is not a repo.
+case "$repo_arg" in release|operational) model="$repo_arg"; repo_arg="" ;; esac
+repo="${repo_arg:-$(gh repo view --json nameWithOwner --jq '.nameWithOwner')}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO="${REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+# ----- Resolve the workflow model (selects the develop ruleset), shared by apply and check -----
+registry="$script_dir/../registry/repos.json"
+name="${repo##*/}"
+if [ -z "$model" ]; then
+    if [ -f "$registry" ]; then
+        # Fail fast on a jq or parse error (a malformed registry) rather than silently applying the release default.
+        # Silently defaulting would hide a lookup that actually broke.
+        # A repo simply absent from the registry is not an error.
+        # The expression falls back through defaults.workflowModel to "release", so jq still exits 0 with a value.
+        if ! model="$(jq -r --arg n "$name" '(.repos[] | select(.name==$n) | .workflowModel) // .defaults.workflowModel // "release"' "$registry")"; then
+            echo "Failed to read workflowModel from $registry (invalid JSON?). Pass the model explicitly (release|operational)." >&2
+            exit 1
+        fi
+    else
+        # With no registry to consult (a downstream carry), infer the model from which develop payload is carried.
+        # A carry holds exactly its own model's payload.
+        # An ambiguous layout (both or neither, as in a partial copy) aborts rather than guesses.
+        # A wrong guess would apply or check the wrong develop ruleset.
+        if [ -f "$script_dir/develop.json" ] && [ ! -f "$script_dir/operational/develop.json" ]; then
+            model="release"
+        elif [ -f "$script_dir/operational/develop.json" ] && [ ! -f "$script_dir/develop.json" ]; then
+            model="operational"
+        else
+            echo "Registry $registry not found and the carried develop payloads are ambiguous (expected exactly one of develop.json or operational/develop.json). Pass the model explicitly (release|operational)." >&2
+            exit 1
+        fi
+        echo "Registry $registry not found. Inferred workflow model '$model' from the carried develop payload." >&2
+    fi
+fi
+case "$model" in
+    release) develop_ruleset="$script_dir/develop.json" ;;
+    operational) develop_ruleset="$script_dir/operational/develop.json" ;;
+    *) echo "Unknown workflow model '$model' (expected release or operational)." >&2; exit 1 ;;
+esac
+main_ruleset="$script_dir/main.json"
+settings_file="$script_dir/settings.json"
 
-# Secrets by store (names only; values are never readable via the API). The Docker Hub credentials and the
-# merge-bot App credentials must be set in BOTH stores: a Dependabot-triggered run gets the Dependabot secret
-# store, not Actions secrets, and that run's push CI builds the Docker smoke, which logs in to Docker Hub.
-# Publishing the GitHub release uses the built-in GITHUB_TOKEN (no secret needed).
-REQUIRED_ACTIONS_SECRETS=(DOCKER_HUB_USERNAME DOCKER_HUB_ACCESS_TOKEN CODEGEN_APP_CLIENT_ID CODEGEN_APP_PRIVATE_KEY)
-REQUIRED_DEPENDABOT_SECRETS=(DOCKER_HUB_USERNAME DOCKER_HUB_ACCESS_TOKEN CODEGEN_APP_CLIENT_ID CODEGEN_APP_PRIVATE_KEY)
-REQUIRED_CHECK="Check pull request workflow status job"
-
-note()  { printf '  %s\n' "$*"; }
-pass()  { printf '  \033[32mok\033[0m   %s\n' "$*"; }
-fail()  { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILED=1; }
-FAILED=0
-
-ruleset_id() { # name -> id (empty if absent); aborts with a visible reason on an API error
-  local out
-  # An absent ruleset is a successful call with no match (empty); only a real API error fails. Let gh print its
-  # own error on stderr (do not suppress it); add a generic context line and return non-zero so the run stops
-  # (the caller's $(...) cannot print the cause itself).
-  # per_page=100 returns every ruleset in one array (a repo has only a handful); the default page size is 30.
-  if ! out="$(gh api "repos/$REPO/rulesets?per_page=100")"; then
-    echo "ERROR: could not list rulesets for $REPO (see gh error above)" >&2
-    return 1
-  fi
-  # shellcheck disable=SC2016  # $n is a jq variable (--arg n), not a shell expansion
-  # Select the first match inside jq (not `| head -1`): under pipefail, head closing the pipe early can
-  # SIGPIPE jq and fail the function.
-  jq -r --arg n "$1" '[.[] | select(.name==$n) | .id] | first // empty' <<<"$out"
+# ----- Ruleset id lookup (shared by apply and check) -----
+# Map a ruleset name to the id of the first match, leaving it empty when nothing matches.
+# It warns on duplicates, and aborts on an API error or at the per_page cap, where a single-fetch lookup is unreliable.
+ruleset_id() {
+    local out ids count
+    # Requesting per_page=100 returns every ruleset in one array, since a repo carries only a handful.
+    # The response is then a single JSON document, where a paginated fetch would concatenate arrays and break the jq below.
+    # Let gh print its own error on stderr.
+    # Add a context line and return non-zero, so the caller stops rather than treat an API failure as "not found".
+    if ! out="$(gh api "repos/$repo/rulesets?per_page=100")"; then
+        echo "Failed to list rulesets for $repo (check auth and repo access)." >&2
+        return 1
+    fi
+    # Fail loud rather than silently narrow, because a full page means the single-fetch assumption no longer holds.
+    # A missed lookup would make apply create a duplicate ruleset by name.
+    # Abort so the caller stops, since it treats a non-zero return as "stop" and never as "not found".
+    if [ "$(jq 'length' <<<"$out")" -eq 100 ]; then
+        echo "Failed for $repo: 100 rulesets returned (the per_page cap), so the single-fetch lookup is unreliable. Reduce rulesets or add pagination before applying." >&2
+        return 1
+    fi
+    # shellcheck disable=SC2016  # $n is a jq --arg variable, not a shell expansion
+    ids="$(jq -r --arg n "$1" '.[] | select(.name==$n) | .id' <<<"$out")"
+    if [ -z "$ids" ]; then return 0; fi
+    # Pre-existing drift can leave more than one ruleset with the same name.
+    # Use the first and warn, so the duplicates get resolved rather than silently operating on the wrong one.
+    # Both grep -c and sed read all their input with no early pipe close, so neither SIGPIPEs jq under pipefail.
+    count="$(printf '%s\n' "$ids" | grep -c .)"
+    if [ "$count" -gt 1 ]; then
+        echo "Warning: $count rulesets named '$1' on $repo. Using the first (resolve the duplicates)." >&2
+    fi
+    printf '%s\n' "$ids" | sed -n '1p'
 }
 
-apply_ruleset() {
-  local file="$1" name id
-  name="$(jq -r .name "$file")"
-  id="$(ruleset_id "$name")"
-  if [[ -n "$id" ]]; then
-    gh api -X PUT "repos/$REPO/rulesets/$id" --input "$file" >/dev/null
-    note "updated ruleset '$name' (#$id)"
-  else
-    gh api -X POST "repos/$REPO/rulesets" --input "$file" >/dev/null
-    note "created ruleset '$name'"
-  fi
+# =============================== apply ===============================
+apply_ruleset() { # payload-file - create-or-update the ruleset by name
+    local file="$1" rname id
+    if [ ! -e "$file" ]; then
+        echo "Ruleset payload $file not found. Aborting to avoid a partially-applied configuration." >&2
+        exit 1
+    fi
+    rname="$(jq -r '.name // empty' "$file")"
+    if [ -z "$rname" ]; then
+        echo "Ruleset payload $file has no name. Aborting to avoid a partially-applied configuration." >&2
+        exit 1
+    fi
+    id="$(ruleset_id "$rname")"
+    if [ -n "$id" ]; then
+        echo "Updating ruleset '$rname' (id $id) on $repo"
+        gh api --method PUT "repos/$repo/rulesets/$id" --input "$file" >/dev/null
+    else
+        echo "Creating ruleset '$rname' on $repo"
+        gh api --method POST "repos/$repo/rulesets" --input "$file" >/dev/null
+    fi
 }
 
 cmd_apply() {
-  echo "Applying repository configuration to $REPO"
-  apply_ruleset "$DIR/ruleset-develop.json"
-  apply_ruleset "$DIR/ruleset-main.json"
-  gh api -X PATCH "repos/$REPO" --input "$DIR/settings.json" >/dev/null
-  note "patched repository settings"
-  gh api -X PUT "repos/$REPO/vulnerability-alerts" >/dev/null
-  gh api -X PUT "repos/$REPO/automated-security-fixes" >/dev/null
-  note "enabled Dependabot alerts + security updates"
-  echo "Done. Run '$0 check' to validate."
+    local f private disc payload
+    # Pre-flight every required payload before any write, so a partial carry aborts before it half-applies.
+    for f in "$settings_file" "$develop_ruleset" "$main_ruleset"; do
+        if [ ! -e "$f" ]; then
+            echo "Required payload $f not found. Aborting to avoid a partially-applied configuration." >&2
+            exit 1
+        fi
+    done
+    echo "Applying configuration to $repo (model: $model)"
+    # The writes below silence stdout only, because the success-response JSON is noise.
+    # They still fail loud, since gh errors go to stderr and a failed write aborts the script.
+    # These writes run unguarded under `set -e`.
+    # ----- General repository settings -----
+    # Discussions are enabled on public repos only by fleet policy, and never on a private one.
+    private="$(gh api "repos/$repo" --jq '.private')"
+    disc=false; [ "$private" = "false" ] && disc=true
+    # The default branch is main, but only point it there once main exists.
+    # Never set the default to a missing branch, as on a repo still living on a rework branch.
+    if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
+        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d, default_branch: "main"}' "$settings_file")"
+    else
+        payload="$(jq --argjson d "$disc" '. + {has_discussions: $d}' "$settings_file")"
+        echo "Warning: $repo has no 'main' branch. Leaving default_branch unchanged." >&2
+    fi
+    echo "Applying general settings (has_discussions=$disc)"
+    printf '%s' "$payload" | gh api --method PATCH "repos/$repo" --input - >/dev/null
+    # ----- Dependabot alerts + automated security updates -----
+    gh api --method PUT "repos/$repo/vulnerability-alerts" >/dev/null
+    gh api --method PUT "repos/$repo/automated-security-fixes" >/dev/null
+    echo "Enabled Dependabot vulnerability alerts + automated security updates"
+    # ----- Branch rulesets (main shared, develop selected by workflow model) -----
+    apply_ruleset "$develop_ruleset"
+    apply_ruleset "$main_ruleset"
+    echo "Configuration applied to $repo. Run '$0 check${repo_arg:+ $repo}' to validate."
 }
 
-# --- validation (5D) -------------------------------------------------------------------------------
+# =============================== check ===============================
+FAILED=0
+note() { printf '  %s\n' "$*"; }
+pass() { printf '  ok   %s\n' "$*"; }
+fail() { printf '  FAIL %s\n' "$*"; FAILED=1; }
 
-# assert MESSAGE TEST... - run the test command; pass on success, fail on non-zero (proper if/else, not
-# the A && B || C footgun). The test command may read stdin (e.g. a `<<<` heredoc on the assert call).
-# Do not redirect the assert call's stdout - that would also swallow the pass/fail line; commands that
-# print (jq) use `jq_has`, which silences only itself.
-assert() {
-  local msg="$1"; shift
-  if "$@"; then pass "$msg"; else fail "$msg"; fi
-}
+# Run a test command with `assert MESSAGE TEST...`, passing on success and failing on non-zero.
+# It is a proper if/else rather than the `A && B || C` footgun.
+# Do not redirect the assert call's own stdout, which would swallow the pass or fail line.
+# A command that prints, such as jq, goes through jq_has, which silences only itself.
+assert() { local msg="$1"; shift; if "$@"; then pass "$msg"; else fail "$msg"; fi; }
 
-# jq_has FILTER... - true iff the jq filter selects something; jq's own output is discarded, not the
-# caller's. Reads JSON from stdin.
+# Test with `jq_has FILTER...`, which is true only when the filter selects a truthy value.
+# The jq output is discarded, not the caller's.
+# It reads its JSON from stdin.
 jq_has() { jq -e "$@" >/dev/null 2>&1; }
 
-# jq_lacks FILTER... - true iff the jq filter yields no truthy value (selects nothing, or only false/null).
-# `jq -e` exits 1 (last output false/null) or 4 (no output at all) for the "lacks" cases, 0 for a truthy
-# match, and 2/3/5 for a real error (malformed filter or input), which is propagated so the calling assert
-# fails loudly. The `|| rc=$?` keeps jq in a list (exempt from set -e) so a non-zero exit captures rc instead
-# of aborting. Only stdout is discarded - jq's stderr is kept so a real error shows its diagnostic.
-jq_lacks() { local rc=0; jq -e "$@" >/dev/null || rc=$?; case "$rc" in 0) return 1 ;; 1|4) return 0 ;; *) return "$rc" ;; esac; }
-
-check_ruleset() { # name  expected-merge-method  expect-linear(true/false)
-  local name="$1" method="$2" linear="$3" id rs
-  id="$(ruleset_id "$name")"
-  if [[ -z "$id" ]]; then fail "ruleset '$name' missing"; return; fi
-  rs="$(gh api "repos/$REPO/rulesets/$id")"
-  assert "ruleset '$name' active" \
-    test "$(jq -r '.enforcement' <<<"$rs")" = active
-  assert "'$name' merge method = $method" \
-    test "$(jq -r '.rules[] | select(.type=="pull_request") | .parameters.allowed_merge_methods | join(",")' <<<"$rs")" = "$method"
-  assert "'$name' requires signed commits" \
-    jq_has '.rules[] | select(.type=="required_signatures")' <<<"$rs"
-  assert "'$name' strict status policy off" \
-    test "$(jq -r '.rules[] | select(.type=="required_status_checks") | .parameters.strict_required_status_checks_policy' <<<"$rs")" = false
-  # shellcheck disable=SC2016  # $c is a jq variable (--arg c), not a shell expansion
-  assert "'$name' requires '$REQUIRED_CHECK'" \
-    jq_has --arg c "$REQUIRED_CHECK" '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks[] | select(.context==$c)' <<<"$rs"
-  if [[ "$linear" == "true" ]]; then
-    assert "'$name' requires linear history" \
-      jq_has '.rules[] | select(.type=="required_linear_history")' <<<"$rs"
-  else
-    # main must NOT require linear history - it would block the develop -> main merge-commit promotion.
-    assert "'$name' does not require linear history" \
-      jq_lacks '.rules[] | select(.type=="required_linear_history")' <<<"$rs"
-  fi
-}
-
-# gh_ok ENDPOINT... - true iff the gh api call succeeds (2xx, including 204). Output and errors are
-# discarded, so it is safe to pass to `assert`.
+# Test with `gh_ok ENDPOINT...`, which is true only when the gh api call succeeds, a 204 included.
+# Output and errors are both discarded, so it is safe to pass to assert.
+# The vulnerability-alerts endpoint is the example, returning 204 when enabled and 404 when disabled.
 gh_ok() { gh api "$@" >/dev/null 2>&1; }
 
+check_ruleset() { # payload-file - the live ruleset must match the committed policy, driven by the payload
+    local file="$1" rname id live t want got wantc gotc want_enf
+    if [ ! -e "$file" ]; then fail "ruleset payload $file missing"; return; fi
+    rname="$(jq -r '.name // empty' "$file")"
+    if [ -z "$rname" ]; then fail "ruleset payload $file has no name"; return; fi
+    if ! id="$(ruleset_id "$rname")"; then fail "ruleset '$rname' - could not resolve id"; return; fi
+    if [ -z "$id" ]; then fail "ruleset '$rname' missing"; return; fi
+    if ! live="$(gh api "repos/$repo/rulesets/$id")"; then fail "ruleset '$rname' - could not read live state"; return; fi
+    want_enf="$(jq -r '.enforcement' "$file")"
+    assert "ruleset '$rname' enforcement = $want_enf" test "$(jq -r '.enforcement' <<<"$live")" = "$want_enf"
+    # Every rule type the committed payload declares must be present live (payload-driven, so repo-agnostic).
+    while IFS= read -r t; do
+        # shellcheck disable=SC2016  # $t is a jq --arg variable, not a shell expansion
+        assert "'$rname' enforces rule '$t'" jq_has --arg t "$t" '.rules[] | select(.type==$t)' <<<"$live"
+    done < <(jq -r '.rules[].type' "$file")
+    # For pull_request, the live merge methods must match the payload, which is the develop=squash and main=merge policy.
+    if jq_has '.rules[] | select(.type=="pull_request")' "$file"; then
+        want="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' "$file")"
+        got="$(jq -c '[.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods[]]|sort' <<<"$live")"
+        assert "'$rname' merge methods = $want" test "$got" = "$want"
+    fi
+    # For required_status_checks, the live required contexts must match the payload.
+    if jq_has '.rules[] | select(.type=="required_status_checks")' "$file"; then
+        wantc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' "$file")"
+        gotc="$(jq -c '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]|sort' <<<"$live")"
+        assert "'$rname' required checks = $wantc" test "$gotc" = "$wantc"
+    fi
+}
+
 check_settings() {
-  local s; s="$(gh api "repos/$REPO")"
-  # Drive every assertion from settings.json, so the check covers exactly the applied desired state and
-  # never drifts from the file (add a key there and it is audited here automatically).
-  local key want got
-  while IFS=$'\t' read -r key want; do
-    # shellcheck disable=SC2016  # $k is a jq variable (--arg k), not a shell expansion
-    got="$(jq -r --arg k "$key" '.[$k]' <<<"$s")"
-    assert "setting $key = $want" test "$got" = "$want"
-  done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$DIR/settings.json")
+    local live key want got private wantdisc
+    if [ ! -e "$settings_file" ]; then fail "settings payload $settings_file missing"; return; fi
+    if ! live="$(gh api "repos/$repo")"; then fail "could not read repository settings"; return; fi
+    # Static settings are driven from settings.json, so the check never drifts from the file.
+    # Add a key there and it is audited here automatically.
+    while IFS=$'\t' read -r key want; do
+        # shellcheck disable=SC2016  # $k is a jq --arg variable, not a shell expansion
+        got="$(jq -r --arg k "$key" '.[$k]' <<<"$live")"
+        assert "setting $key = $want" test "$got" = "$want"
+    done < <(jq -r 'to_entries[] | "\(.key)\t\(.value)"' "$settings_file")
+    # Dynamic settings apply sets: has_discussions (public repos only), default_branch (main, if it exists).
+    private="$(jq -r '.private' <<<"$live")"
+    wantdisc=true; [ "$private" = "true" ] && wantdisc=false
+    assert "has_discussions = $wantdisc" test "$(jq -r '.has_discussions' <<<"$live")" = "$wantdisc"
+    if gh api "repos/$repo/branches/main" --jq '.name' >/dev/null 2>&1; then
+        assert "default_branch = main" test "$(jq -r '.default_branch' <<<"$live")" = main
+    fi
 }
 
 check_security() {
-  # apply enables both; audit that they are still on. vulnerability-alerts returns 204 when enabled and
-  # 404 when disabled; automated-security-fixes returns { "enabled": true/false }.
-  assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$REPO/vulnerability-alerts"
-  assert "Dependabot automated security updates enabled" \
-    jq_has '.enabled == true' < <(gh api "repos/$REPO/automated-security-fixes")
-}
-
-check_secrets() {
-  # --paginate: the secrets endpoints page at 30, so without it a repo with many secrets could miss a
-  # required name and report a false failure. An API/auth error FAILs fast (the required secrets cannot be
-  # verified, so reporting "matches" would be wrong) - distinct from a genuinely missing secret, which also
-  # FAILs. gh prints its own error (stderr not suppressed) so the cause is actionable.
-  local actions deps
-  if ! actions="$(gh api --paginate "repos/$REPO/actions/secrets" --jq '.secrets[].name')"; then
-    fail "could not list Actions secrets (API error - cannot verify required secrets)"; return
-  fi
-  if ! deps="$(gh api --paginate "repos/$REPO/dependabot/secrets" --jq '.secrets[].name')"; then
-    fail "could not list Dependabot secrets (API error - cannot verify required secrets)"; return
-  fi
-  for s in "${REQUIRED_ACTIONS_SECRETS[@]}"; do
-    assert "actions secret $s present" grep -qx "$s" <<<"$actions"
-  done
-  for s in "${REQUIRED_DEPENDABOT_SECRETS[@]}"; do
-    assert "dependabot secret $s present" grep -qx "$s" <<<"$deps"
-  done
-}
-
-check_app() {
-  # Best-effort: confirm a GitHub App installation backs the merge-bot automation. A precise check
-  # requires app-level auth; presence of the App secrets above is the practical proxy.
-  if gh api "repos/$REPO/installation" >/dev/null 2>&1; then
-    pass "a GitHub App is installed on the repo"
-  else
-    note "could not confirm App installation via this token (verify the merge-bot App is installed)"
-  fi
+    local sec
+    # The vulnerability-alerts endpoint returns 204 when enabled and 404 when disabled, so probe it with gh_ok.
+    # The automated-security-fixes endpoint returns a JSON body of { enabled, paused }.
+    # That one is captured under an explicit failure guard, so a read error is a clean FAIL rather than a set -e abort.
+    assert "Dependabot vulnerability alerts enabled" gh_ok "repos/$repo/vulnerability-alerts"
+    if sec="$(gh api "repos/$repo/automated-security-fixes" 2>/dev/null)"; then
+        assert "Dependabot automated security updates enabled" jq_has '.enabled == true' <<<"$sec"
+    else
+        fail "Dependabot automated security updates - could not read the setting"
+    fi
 }
 
 cmd_check() {
-  echo "Validating repository configuration for $REPO"
-  check_ruleset develop squash true
-  check_ruleset main   merge  false
-  check_settings
-  check_security
-  check_secrets
-  check_app
-  # Not checkable via gh api beyond name presence: that DOCKER_HUB_ACCESS_TOKEN is valid and has push
-  # access to docker.io/ptr727/vscode-server-dotnetcore. Verify it by hand in the Docker Hub account.
-  note "verify manually: Docker Hub access token valid with push to docker.io/ptr727/vscode-server-dotnetcore"
-  if [[ "$FAILED" -ne 0 ]]; then echo "Configuration drift detected."; exit 1; fi
-  echo "Configuration matches."
+    echo "Validating configuration for $repo (model: $model)"
+    check_ruleset "$develop_ruleset"
+    check_ruleset "$main_ruleset"
+    check_settings
+    check_security
+    # Secrets are per-repo (spec/secrets.json) and not readable by value.
+    # A standalone carry has no registry to derive the required set from, so they are verified by hand rather than asserted here.
+    note "verify manually: the repo's required secrets (see spec/secrets.json) are present with valid values"
+    if [ "$FAILED" -ne 0 ]; then echo "Configuration drift detected on $repo."; exit 1; fi
+    echo "Configuration matches on $repo."
 }
 
-case "${1:-check}" in
-  apply) cmd_apply ;;
-  check) cmd_check ;;
-  *) echo "usage: $0 [apply|check]" >&2; exit 2 ;;
+case "$cmd" in
+    apply) cmd_apply ;;
+    check) cmd_check ;;
 esac


### PR DESCRIPTION
`.markdownlint-cli2.jsonc` is carried `verbatim` from ptr727/ProjectTemplate, so a copy that differs is drift rather than a choice. The hub's regenerated fleet divergence report lists this repo for it.

The canonical enables `MD033` with `details` and `summary` allowed, which is a behavior change rather than a comment sweep. Verified rather than assumed, since that is the kind of change that fails CI after the fact: `markdownlint-cli2` over `**/*.md` reports **0 issues** here under the restored config.

Line endings preserved.

## `repo-config/configure.sh` was withdrawn from this pull request

An earlier revision of this branch also re-vendored `repo-config/configure.sh`, and this description still described it after the file was removed. That was a stale description rather than a missing commit, and it is corrected here.

The reason it was withdrawn is worth stating, because it is the blocker for this repo: the canonical script resolves its ruleset payloads as `develop.json` and `main.json`, and this repo carries `ruleset-develop.json` and `ruleset-main.json`. Copying the script in leaves `apply` and `check` aborting on payloads that do not exist, which is worse than the older script it replaced. The hub's divergence ledger recorded the filename fork, so the information was available and the re-vendor ran without acting on it.

Converging this repo needs the payload migration with its content reconciled against the canonical, which is judgment rather than a file copy, so it gets its own pull request. Known defects in the canonical script are tracked at ptr727/ProjectTemplate#538 and fixed in ptr727/ProjectTemplate#540, which should land before that migration so this repo takes a corrected script rather than the current one twice.

Part of the fleet re-vendor sweep tracked in the hub's `TODO.md`.
